### PR TITLE
Fix terminal check

### DIFF
--- a/ESPLoader.js
+++ b/ESPLoader.js
@@ -641,14 +641,14 @@ class ESPLoader {
     }
 
     log(str) {
-        if (this.transport) {
+        if (this.terminal) {
             this.terminal.writeln(str);
         } else {
             console.log(str);
         }
     }
     write_char(str) {
-        if (this.transport) {
+        if (this.terminal) {
             this.terminal.write(str);
         } else {
             console.log(str);


### PR DESCRIPTION
The `log` and `write_char` methods incorrectly checked if `this.transport` was set before calling a method on `this.terminal`. Looks like this should be a check against `this.terminal` instead.