### PR TITLE
Allow installing this repository with NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "esptool-js",
   "dependencies": {
     "crypto-js": "^4.0.0",
     "xterm": "^4.13.0"


### PR DESCRIPTION
Adding a name to `package.json` allows NPM to install this repository.