### PR TITLE
Fix for erase causing error

### DIFF
--- a/ESPLoader.js
+++ b/ESPLoader.js
@@ -767,7 +767,7 @@ class ESPLoader {
         }
 
         if (this.IS_STUB === true && erase_all === true) {
-            this.erase_flash();
+            await this.erase_flash();
         }
         let image, address;
         for (var i = 0; i < fileArray.length; i++) {


### PR DESCRIPTION
When passing the flash to erase flash when flashing the flashing process would fail because the erase was to awaited, which means the erase is happening in parallel with the flash!