### PR TITLE
Allow specifying the initial 'rom-baudrate' in constructor

### DIFF
--- a/ESPLoader.js
+++ b/ESPLoader.js
@@ -48,10 +48,11 @@ class ESPLoader {
 
     DETECTED_FLASH_SIZES = {0x12: '256KB', 0x13: '512KB', 0x14: '1MB', 0x15: '2MB', 0x16: '4MB', 0x17: '8MB', 0x18: '16MB'};
 
-    constructor(transport, baudrate, terminal) {
+    constructor(transport, baudrate, terminal, rom_baudrate = 115200) {
         this.transport = transport;
         this.baudrate = baudrate;
         this.terminal = terminal;
+        this.rom_baudrate = rom_baudrate;
         this.IS_STUB = false;
         this.chip = null;
 
@@ -280,7 +281,7 @@ class ESPLoader {
         var resp;
         this.chip = null;
         this.write_char('Connecting...');
-        await this.transport.connect();
+        await this.transport.connect({baud:this.rom_baudrate});
         for (i = 0 ; i < attempts; i++) {
             resp = await this._connect_attempt({mode:mode, esp32r0_delay:false});
             if (resp === "success") {


### PR DESCRIPTION
By allowing the user to specify the `rom_baudrate` at construction time this allows devices that are programmed via serial-passthrough to perform any pre-flashing commands they may need to do before calling the `main_fn` and not have the main function change the baudrate.

We use this in ExpressLRS as we need to perform passthrough initialisation of a flight-controller before calling the `main_fn` etc to perform the flashing. The flight controller talks to the receiver at 420k, and will do the passthrough at another specified rate, but cannot change rate, so the initial `rom_baudrate` and the `baudrate` used by `change_baud` must be the same in our case.