### PR TITLE
fixed ESP32-C3: "app image at 0x10000 has invalid magic byte" if the …

### DIFF
--- a/ESPLoader.js
+++ b/ESPLoader.js
@@ -777,7 +777,10 @@ class ESPLoader {
         let image, address;
         for (var i = 0; i < fileArray.length; i++) {
             console.log("Data Length " + fileArray[i].data.length);
-            image = fileArray[i].data + '\xff\xff\xff\xff'.substring(0, 4 - fileArray[i].data.length % 4);
+
+            image = fileArray[i].data;
+            const reminder = fileArray[i].data.length % 4;
+            if (reminder > 0) image += '\xff\xff\xff\xff'.substring(4 - reminder);
             address = fileArray[i].address;
             console.log("Image Length " + image.length);
             if (image.length === 0) {

--- a/targets/esp32c3.js
+++ b/targets/esp32c3.js
@@ -8,7 +8,7 @@ export default class ESP32C3ROM {
   static UART_DATE_REG_ADDR = 0x6000007c;
 
   static FLASH_WRITE_SIZE = 0x400;
-  static BOOTLOADER_FLASH_OFFSET = 0x1000;
+  static BOOTLOADER_FLASH_OFFSET = 0;
 
   static FLASH_SIZES = {
     "1MB": 0x00,


### PR DESCRIPTION
Fixed issue #48

if fileArray[i].data.length % 4 == 0,  there will be extra 4 bytes, so overlap with the following image
`image = fileArray[i].data + '\xff\xff\xff\xff'.substring(0, 4 - fileArray[i].data.length % 4);`
btw:
1.  the address of C3 bootloader is 0x0