### PR TITLE
support build-in USB-JTAG-Serial

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         />
         <link rel="icon" href="favicon.ico" />
          <script src="https://cdn.jsdelivr.net/npm/xterm@4.19.0/lib/xterm.min.js"></script>
-         <script src="https://cdn.jsdelivr.net/npm/crypto-js@4.1.1/index.min.js"></script>
+         <script src="https://cdn.jsdelivr.net/npm/crypto-js@4.1.1/crypto-js.js"></script>
          <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
          <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     </head>

--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -12,6 +12,10 @@ class Transport {
       : "";
   }
 
+  get_pid() {
+    return this.device.getInfo().usbProductId;
+  }
+
   slip_writer(data: Uint8Array) {
     let count_esc = 0;
     let i = 0,
@@ -181,11 +185,18 @@ class Transport {
     }
   }
 
+  _DTR_state = false;
   async setRTS(state: boolean) {
     await this.device.setSignals({ requestToSend: state });
+    // # Work-around for adapters on Windows using the usbser.sys driver:
+    // # generate a dummy change to DTR so that the set-control-line-state
+    // # request is sent with the updated RTS state and the same DTR state
+    // Referenced to esptool.py
+    await this.setDTR(this._DTR_state);
   }
 
   async setDTR(state: boolean) {
+    this._DTR_state = state;
     await this.device.setSignals({ dataTerminalReady: state });
   }
 


### PR DESCRIPTION
esp32c3 esp32s3 have a built-in USB serial. 
When connect them direct by usb, without external usb-serial-bridge(ch340 etc.), send correct sequence of handshake signals can put the chip into download mode.
The specific sequence can be found from esp32s3 datasheet `33.4.2 Runtime operation`.
