### PR TITLE
fix: timeout error on connecting

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -353,7 +353,6 @@ export class ESPLoader {
     }
     this.write_char("\n");
     this.write_char("\r");
-    await this.flush_input();
 
     if (!detecting) {
       const chip_magic_value = (await this.read_reg(0x40001000)) >>> 0;


### PR DESCRIPTION
Fixes an issue reported in #55 #58

In a version used in gh-pages, there was a typo: `readRaw` instead of `rawRead` but since it was try/catched, the error didn't show up.

In typescript update, typo was fixed, but that caused a timeout issue.

Not sure, if it should just be deleted or it should be used differently.