### PR TITLE
Separate info from debug logging, remove unused code

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const programDiv = document.getElementById('program');
 const consoleDiv = document.getElementById('console');
 const lblBaudrate = document.getElementById('lblBaudrate');
 const lblConnTo = document.getElementById('lblConnTo');
-const tableBody = document.getElementById('tableBody');
 const table = document.getElementById('fileTable');
 const alertDiv = document.getElementById('alertDiv');
 
@@ -30,32 +29,12 @@ let chip = null;
 let esploader;
 let file1 = null;
 let connected = false;
-let index = 1;
 
 disconnectButton.style.display = 'none';
 eraseButton.style.display = 'none';
 consoleStopButton.style.display = 'none';
 filesDiv.style.display = 'none';
 
-function convertUint8ArrayToBinaryString(u8Array) {
-  var i,
-    len = u8Array.length,
-    b_str = '';
-  for (i = 0; i < len; i++) {
-    b_str += String.fromCharCode(u8Array[i]);
-  }
-  return b_str;
-}
-
-function convertBinaryStringToUint8Array(bStr) {
-  var i,
-    len = bStr.length,
-    u8_array = new Uint8Array(len);
-  for (var i = 0; i < len; i++) {
-    u8_array[i] = bStr.charCodeAt(i);
-  }
-  return u8_array;
-}
 
 function handleFileSelect(evt) {
   var file = evt.target.files[0];
@@ -74,10 +53,6 @@ function handleFileSelect(evt) {
   reader.readAsBinaryString(file);
 }
 
-function _sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 let espLoaderTerminal = {
   clean() {
     term.clear();
@@ -91,10 +66,6 @@ let espLoaderTerminal = {
 }
 
 connectButton.onclick = async () => {
-  //    device = await navigator.usb.requestDevice({
-  //        filters: [{ vendorId: 0x10c4 }]
-  //    });
-
   if (device === null) {
     device = await navigator.serial.requestPort({});
     transport = new Transport(device);

--- a/src/targets/esp32.ts
+++ b/src/targets/esp32.ts
@@ -39,7 +39,7 @@ export class ESP32ROM extends ROM {
 
   public async read_efuse(loader: ESPLoader, offset: number) {
     const addr = this.EFUSE_RD_REG_BASE + 4 * offset;
-    loader.log("Read efuse " + addr);
+    loader.debug("Read efuse " + addr);
     return await loader.read_reg(addr);
   }
 
@@ -171,7 +171,7 @@ export class ESP32ROM extends ROM {
       norm_xtal = 26;
     }
     if (Math.abs(norm_xtal - ets_xtal) > 1) {
-      loader.log("WARNING: Unsupported crystal in use");
+      loader.info("WARNING: Unsupported crystal in use");
     }
     return norm_xtal;
   }

--- a/src/targets/esp32s3.ts
+++ b/src/targets/esp32s3.ts
@@ -56,7 +56,7 @@ export class ESP32S3ROM extends ROM {
 
   public async _post_connect(loader: ESPLoader) {
     const buf_no = (await loader.read_reg(this.UARTDEV_BUF_NO)) & 0xff;
-    console.log("In _post_connect " + buf_no);
+    loader.debug("In _post_connect " + buf_no);
     if (buf_no == this.UARTDEV_BUF_NO_USB) {
       loader.ESP_RAM_BLOCK = this.USB_RAM_BLOCK;
     }

--- a/src/targets/esp8266.ts
+++ b/src/targets/esp8266.ts
@@ -44,7 +44,7 @@ export class ESP8266ROM extends ROM {
 
   public async read_efuse(loader: ESPLoader, offset: number) {
     const addr = this.EFUSE_RD_REG_BASE + 4 * offset;
-    loader.log("Read efuse " + addr);
+    loader.debug("Read efuse " + addr);
     return await loader.read_reg(addr);
   }
 
@@ -72,7 +72,7 @@ export class ESP8266ROM extends ROM {
       norm_xtal = 26;
     }
     if (Math.abs(norm_xtal - ets_xtal) > 1) {
-      loader.log(
+      loader.info(
         "WARNING: Detected crystal freq " +
           ets_xtal +
           "MHz is quite different to normalized freq " +
@@ -110,7 +110,7 @@ export class ESP8266ROM extends ROM {
       mac[1] = 0xd0;
       mac[2] = 0x74;
     } else {
-      loader.log("Unknown OUI");
+      loader.error("Unknown OUI");
     }
 
     mac[3] = (mac1 >> 8) & 0xff;

--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -111,7 +111,6 @@ class Transport {
   }
 
   async read(timeout = 0, min_data = 12) {
-    console.log("Read with timeout " + timeout);
     let t;
     let packet = this.left_over;
     this.left_over = new Uint8Array(0);


### PR DESCRIPTION
* Remove commented-out or unused code
* Define separate functions for logging at error/info/debug level
   * Introduce `loader.error(msg)`, `loader.info(msg)`, `loader.debug(msg)`
   * Debug messages are disabled by default, can be enabled via an argument of ESPLoader constructor.
   * Breaking change: `loader.log(msg)` replaced with `loader.info(msg)`, `loader.write_char()` replaced with `loader.info(msg, false)`

Preview at https://igrr.github.io/esptool-js/

Closes https://github.com/espressif/esptool-js/issues/63