### PR TITLE
Clean up unused import

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -1,5 +1,5 @@
 import { ESPError } from "./error";
-import { inflate, deflate } from "pako";
+import { deflate } from "pako";
 import { Transport } from "./webserial";
 import { ROM } from "./targets/rom";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,10 @@
     "allowSyntheticDefaultImports": true,
     "outDir": "./lib",
     "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
     "lib": ["ES2020", "DOM"],
     "importHelpers": true,
     "resolveJsonModule": true


### PR DESCRIPTION
PR https://github.com/espressif/esptool-js/pull/65 left an unused import. This updates the TypeScript config to warn for this + fixes it.