### PR TITLE
Enable strict mode, fix errors

### DIFF
--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -122,7 +122,7 @@ class Transport {
       packet = this.left_over;
       this.left_over = new Uint8Array(0);
     }
-    if (typeof this.device.readable == "undefined") {
+    if (this.device.readable == null) {
       return this.left_over;
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2020", "DOM"],
     "importHelpers": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Enable [strict mode](https://www.typescriptlang.org/tsconfig#strict), fix reported errors.

The current draft still has one issue remaining:
```
src/esploader.ts:101:5 - error TS2322: Type 'null' is not assignable to type 'ROM'.

101     this.chip = null;
        ~~~~~~~~~
```

(`this.chip` gets set to a non-null value later, in `connect` method.)

I'm not sure what's the best way to solve this one. Essentially, we have an assumption that until ESPLoader.connect function is called, the rest of the ESPLoader functions can't be used, since they rely on `ESPLoader.chip` being set.

I see two solutions to this problem:
* Add a bunch of checks/asserts in all methods except `connect` that `.chip` is non-null
* Refactor the code to use typestates: have distinct types for "not yet connected loader" and "already connected loader":
   ```ts
   loaderConnector = new ESPLoaderConnector(transport, baudrates.value, espLoaderTerminal);
   loader: ESPLoader = loaderConnector.connect(mode);
   loader.write_flash(...);
   ```
   This way, when ESPLoader is constructed, `chip` is guaranteed to be known, and we can declare it as `ROM` type.

There might be some other less invasive or simpler solution, so I'm open to suggestions!

Should fix https://github.com/espressif/esptool-js/issues/70