### PR TITLE
use rollup script for publish prepare script

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Node modules
         run: |
           npm install
-          npm run rollup
+          npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Visit https://espressif.github.io/esptool-js/ to see this tool in action.
 
 ```
 npm install
-npm run rollup
+npm run build
 python3 -m http.server 8008
 ```
 
-Then open http://localhost:8008 in Chrome or Edge. The `npm run rollup` step builds the `bundle.js` used in the example `index.html`.
+Then open http://localhost:8008 in Chrome or Edge. The `npm run build` step builds the `bundle.js` used in the example `index.html`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -9,15 +9,14 @@
     "bundle.js"
   ],
   "scripts": {
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && rollup --config",
     "clean": "rimraf lib bundle.js",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint . --ext .ts",
     "lintAndFix": "eslint . --ext .ts --fix",
     "prepare": "npm run build",
     "test": "echo \"Error: no test specified\"",
-    "prepublishOnly": "npm run test && npm run lint",
-    "rollup": "npm run build && rollup --config"
+    "prepublishOnly": "npm run test && npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apologies for npm release we should use `rollup` script in the prepare script (which is run before the npm publish script.

This should be merged before 0.2.0 release.