### PR TITLE
rm unused package json dependencies

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Install Node modules
         run: |
           npm install
+      - name: Build project
+        run: |
           npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "name": "esptool-js",
       "version": "0.1.0",
       "dependencies": {
-        "crypto-js": "^4.0.0",
         "pako": "^2.1.0",
-        "tslib": "^2.4.1",
-        "xterm": "^4.13.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@rollup/plugin-babel": "^6.0.2",
@@ -1606,11 +1604,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2571,9 +2564,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -3564,11 +3557,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -4767,11 +4755,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5488,9 +5471,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "peer": true
     },
@@ -6159,11 +6142,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
     "url": "https://github.com/espressif/esptool-js/issues"
   },
   "dependencies": {
-    "crypto-js": "^4.0.0",
     "pako": "^2.1.0",
-    "tslib": "^2.4.1",
-    "xterm": "^4.13.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^6.0.2",


### PR DESCRIPTION
Remove unused dependencies from package.json, `crypto-js` and `xterm` or its alternatives should be implemented by consuming users.

Separate install and build steps in GitHub pages workflow.