### PR TITLE
Remove hardcoded version

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -104,7 +104,7 @@ export class ESPLoader {
       this.terminal.clean();
     }
 
-    this.info("esptool.js v0.1-dev");
+    this.info("esptool.js");
     this.info("Serial port " + this.transport.get_info());
   }
 


### PR DESCRIPTION
This removes the hardcoded version number.

I would prefer if we could include the actual version number. So maybe we should have a small build script to create that a file like `cat package.json | jq .version`