### PR TITLE
add a devcontainer and common vscode task definitions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "esptool.js",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18-bullseye",
+
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/npm-package:1": {
+			"package": "http-server"
+		}
+	},
+	"forwardPorts": [ 5001 ],
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"task.allowAutomaticTasks": "on"
+			}
+		}
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lib
 bundle.js
 esptool-js-*.tgz
+.vscode/settings.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"label": "npm: build",
+			"detail": "npm run clean && tsc && rollup --config"
+		},
+		{
+			"type": "npm",
+			"script": "install",
+			"label": "NPM install",
+			"runOptions": {
+				"runOn": "folderOpen"
+			}
+		},
+		{
+			"type": "npm",
+			"script": "lint",
+			"problemMatcher": [
+				"$eslint-stylish"
+			],
+			"label": "npm: lint"
+		},
+		{
+			"type": "shell",
+			"label": "HTTP server",
+			"command": "http-server -p 5001",
+			"isBackground": true,
+			"runOptions": {
+				"runOn": "folderOpen"
+			}
+		}
+	]
+}


### PR DESCRIPTION
This adds a devcontainer and VS Code tasks configuration, allowing for easy set-up of the development environment.

I've tested this both locally in VS Code and in Github Codespaces.

Closes https://github.com/espressif/esptool-js/issues/79