### PR TITLE
add reset functions

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -295,7 +295,7 @@ export class ESPLoader {
         // is connecting via its USB-JTAG-Serial peripheral
         await usbJTAGSerialReset(this.transport);
       } else {
-        let strSequence = esp32r0_delay ? "D0|R1|W100|W2000|D1|R0|W50|D0": "D0|R1|W100|D1|R0|W50|D0";
+        const strSequence = esp32r0_delay ? "D0|R1|W100|W2000|D1|R0|W50|D0" : "D0|R1|W100|D1|R0|W50|D0";
         await customReset(this.transport, strSequence);
       }
     }

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -2,6 +2,7 @@ import { ESPError } from "./error";
 import { Data, deflate, Inflate } from "pako";
 import { Transport } from "./webserial";
 import { ROM } from "./targets/rom";
+import { customReset, usbJTAGSerialReset } from "./reset";
 
 async function magic2Chip(magic: number): Promise<ROM | null> {
   switch (magic) {
@@ -292,36 +293,10 @@ export class ESPLoader {
       if (this.transport.get_pid() === this.USB_JTAG_SERIAL_PID) {
         // Custom reset sequence, which is required when the device
         // is connecting via its USB-JTAG-Serial peripheral
-        await this.transport.setRTS(false);
-        await this.transport.setDTR(false);
-        await this._sleep(100);
-
-        await this.transport.setDTR(true);
-        await this.transport.setRTS(false);
-        await this._sleep(100);
-
-        await this.transport.setRTS(true);
-        await this.transport.setDTR(false);
-        await this.transport.setRTS(true);
-
-        await this._sleep(100);
-        await this.transport.setRTS(false);
-        await this.transport.setDTR(false);
+        await usbJTAGSerialReset(this.transport);
       } else {
-        await this.transport.setDTR(false);
-        await this.transport.setRTS(true);
-        await this._sleep(100);
-        if (esp32r0_delay) {
-          //await this._sleep(1200);
-          await this._sleep(2000);
-        }
-        await this.transport.setDTR(true);
-        await this.transport.setRTS(false);
-        if (esp32r0_delay) {
-          //await this._sleep(400);
-        }
-        await this._sleep(50);
-        await this.transport.setDTR(false);
+        let strSequence = esp32r0_delay ? "D0|R1|W100|W2000|D1|R0|W50|D0": "D0|R1|W100|D1|R0|W50|D0";
+        await customReset(this.transport, strSequence);
       }
     }
     let i = 0;

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -76,19 +76,19 @@ export function validateCustomResetStringSequence(seqStr: string): boolean {
 
 /**
  * Custom reset strategy defined with a string.
- * 
+ *
  * The sequenceString input string consists of individual commands divided by "|".
- * 
+ *
  * Commands (e.g. R0) are defined by a code (R) and an argument (0).
- * 
+ *
  * The commands are:
- * 
+ *
  * D: setDTR - 1=True / 0=False
- * 
+ *
  * R: setRTS - 1=True / 0=False
- * 
+ *
  * W: Wait (time delay) - positive integer number (miliseconds)
- * 
+ *
  * "D0|R1|W100|D1|R0|W50|D0" represents the classic reset strategy
  */
 export async function customReset(transport: Transport, sequenceString: string) {

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -1,0 +1,114 @@
+import { Transport } from "./webserial";
+
+const DEFAULT_RESET_DELAY = 50;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function classicReset(transport: Transport, resetDelay = DEFAULT_RESET_DELAY) {
+  await transport.setDTR(false);
+  await transport.setRTS(true);
+  await sleep(100);
+  await transport.setDTR(true);
+  await transport.setRTS(false);
+  await sleep(resetDelay);
+  await transport.setDTR(false);
+}
+
+export async function usbJTAGSerialReset(transport: Transport) {
+  await transport.setRTS(false);
+  await transport.setDTR(false);
+  await sleep(100);
+
+  await transport.setDTR(true);
+  await transport.setRTS(false);
+  await sleep(100);
+
+  await transport.setRTS(true);
+  await transport.setDTR(false);
+  await transport.setRTS(true);
+
+  await sleep(100);
+  await transport.setRTS(false);
+  await transport.setDTR(false);
+}
+
+export async function hardReset(transport: Transport, usingUsbOtg = false) {
+  if (usingUsbOtg) {
+    await sleep(200);
+    await transport.setRTS(false);
+    await sleep(200);
+  } else {
+    await sleep(100);
+    await transport.setRTS(false);
+  }
+}
+
+type Command = "D" | "R" | "W";
+
+export function validateCustomResetStringSequence(seqStr: string): boolean {
+  const commands: Command[] = ["D", "R", "W"];
+
+  const commandsList = seqStr.split("|");
+
+  for (const cmd of commandsList) {
+    const code = cmd[0];
+    const arg = cmd.slice(1);
+
+    if (!commands.includes(code as Command)) {
+      return false; // Invalid command code
+    }
+
+    if (code === "D" || code === "R") {
+      if (arg !== "0" && arg !== "1") {
+        return false; // Invalid argument for D and R commands
+      }
+    } else if (code === "W") {
+      const delay = parseInt(arg);
+      if (isNaN(delay) || delay <= 0) {
+        return false; // Invalid argument for W command
+      }
+    }
+  }
+  return true; // All commands are valid
+}
+
+/**
+ * Custom reset strategy defined with a string.
+ * 
+ * The sequenceString input string consists of individual commands divided by "|".
+ * 
+ * Commands (e.g. R0) are defined by a code (R) and an argument (0).
+ * 
+ * The commands are:
+ * 
+ * D: setDTR - 1=True / 0=False
+ * 
+ * R: setRTS - 1=True / 0=False
+ * 
+ * W: Wait (time delay) - positive integer number (miliseconds)
+ * 
+ * "D0|R1|W100|D1|R0|W50|D0" represents the classic reset strategy
+ */
+export async function customReset(transport: Transport, sequenceString: string) {
+  const resetDictionary: { [key: string]: (arg: any) => Promise<void> } = {
+    D: async (arg: boolean) => await transport.setDTR(arg),
+    R: async (arg: boolean) => await transport.setRTS(arg),
+    W: async (delay: number) => await sleep(delay),
+  };
+  try {
+    const isValidSequence = validateCustomResetStringSequence(sequenceString);
+    if (!isValidSequence) {
+      return;
+    }
+    const cmds = sequenceString.split("|");
+    for (const cmd of cmds) {
+      await resetDictionary[cmd[0]](cmd.slice(1));
+    }
+  } catch (error) {
+    throw new Error("Invalid custom reset sequence");
+  }
+}
+
+export default { classicReset, customReset, hardReset, usbJTAGSerialReset, validateCustomResetStringSequence };


### PR DESCRIPTION
Move reset code to a separate file and add multiple reset modes: classic, usb jtag and custom.

@balloob PTAL

Fix #76 