### PR TITLE
Configurable chip erase timeout

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -74,8 +74,7 @@ connectButton.onclick = async () => {
     const flashOptions = {
       transport,
       baudrate: parseInt(baudrates.value),
-      terminal: espLoaderTerminal,
-      chipEraseTimeout: 12000
+      terminal: espLoaderTerminal
     } as LoaderOptions;
     esploader = new ESPLoader(flashOptions);
 

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -75,6 +75,7 @@ connectButton.onclick = async () => {
       transport,
       baudrate: parseInt(baudrates.value),
       terminal: espLoaderTerminal,
+      chipEraseTimeout: 12000
     } as LoaderOptions;
     esploader = new ESPLoader(flashOptions);
 

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -74,7 +74,7 @@ connectButton.onclick = async () => {
     const flashOptions = {
       transport,
       baudrate: parseInt(baudrates.value),
-      terminal: espLoaderTerminal
+      terminal: espLoaderTerminal,
     } as LoaderOptions;
     esploader = new ESPLoader(flashOptions);
 

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -21,6 +21,7 @@ export interface LoaderOptions {
   terminal?: IEspLoaderTerminal;
   romBaudrate: number;
   debugLogging?: boolean;
+  chipEraseTimeout?: number;
 }
 
 async function magic2Chip(magic: number): Promise<ROM | null> {
@@ -123,6 +124,7 @@ export class ESPLoader {
   private terminal?: IEspLoaderTerminal;
   private romBaudrate = 115200;
   private debugLogging = false;
+  private chipEraseTimeout = this.CHIP_ERASE_TIMEOUT;
 
   constructor(options: LoaderOptions) {
     this.IS_STUB = false;
@@ -139,6 +141,9 @@ export class ESPLoader {
     }
     if (options.debugLogging) {
       this.debugLogging = options.debugLogging;
+    }
+    if (options.chipEraseTimeout) {
+      this.chipEraseTimeout = options.chipEraseTimeout;
     }
 
     this.info("esptool.js");
@@ -692,7 +697,7 @@ export class ESPLoader {
       this.ESP_ERASE_FLASH,
       undefined,
       undefined,
-      this.CHIP_ERASE_TIMEOUT,
+      this.chipEraseTimeout,
     );
     d = new Date();
     const t2 = d.getTime();


### PR DESCRIPTION
I have a device where the flash erase takes around 12 seconds and will intermittently fail when the timeout is reached. 

A simple fix would be to increase the default 12 second timeout, but I decided to make it configurable instead making it possible to override it.

I know that the ESPLoader.CHIP_ERASE_TIMEOUT can be overrided by accessing it directly. But considering its naming pattern with upper case I assume that it should be considered a constant.