### PR TITLE
Address 3 issues: baud rate change, flash reading, instantiation with port

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -17,6 +17,7 @@ export interface FlashOptions {
 
 export interface LoaderOptions {
   transport: Transport;
+  port: SerialPort;
   baudrate: number;
   terminal?: IEspLoaderTerminal;
   romBaudrate: number;
@@ -153,6 +154,9 @@ export class ESPLoader {
     }
     if (options.debugLogging) {
       this.debugLogging = options.debugLogging;
+    }
+    if(options.port) {
+      this.transport  = new Transport(options.port);
     }
 
     this.info("esptool.js");

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -835,7 +835,7 @@ export class ESPLoader {
     await this._sleep(50);
     await this.transport.connect(this.baudrate);
 
-    /* original code seemd absolutely unreliable. use retries and less sleep */
+    /* original code seemed absolutely unreliable. use retries and less sleep */
     try {
       let i = 64;
       while (i--) {


### PR DESCRIPTION

### Reading flash memory
the function read_flash() allows reading back the flash

### Baud rate fix
changing the baud rate did not resynchronize properly. added sync and retries.
this way 921600 baud connection works always. before it worked 1 out of 30 connection attempts.

### Instantiation using WebSerial port as well as Transport
simplify caller's code by directly using WebSerial port object if specified.
```
esploader = new ESPLoader({
  port: port,
  baudrate: 921600,
  romBaudrate: 115200
});
```
