### PR TITLE
Mark port optional

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -17,7 +17,7 @@ export interface FlashOptions {
 
 export interface LoaderOptions {
   transport: Transport;
-  port: SerialPort;
+  port?: SerialPort;
   baudrate: number;
   terminal?: IEspLoaderTerminal;
   romBaudrate: number;


### PR DESCRIPTION
It was accidentally marked required. Code already assumes it's optional.

Introduced in https://github.com/espressif/esptool-js/commit/04e337db44c5249016342b477a1827e6409fc31e#r130045791