### PR TITLE
fix rom decoded bootloader data

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -1120,13 +1120,13 @@ export class ESPLoader {
   async runStub() {
     this.info("Uploading stub...");
 
-    let decoded = Buffer.from(this.chip.ROM_TEXT).toString("base64");
+    let decoded = Buffer.from(this.chip.ROM_TEXT, "base64").toString("binary");
     let chardata = decoded.split("").map(function (x) {
       return x.charCodeAt(0);
     });
     const text = new Uint8Array(chardata);
 
-    decoded = Buffer.from(this.chip.ROM_DATA).toString("base64");
+    decoded = Buffer.from(this.chip.ROM_DATA, "base64").toString("binary");
     chardata = decoded.split("").map(function (x) {
       return x.charCodeAt(0);
     });


### PR DESCRIPTION
This should fix the stub failing during initial connection.

Apologies, tried to replace atob method but method was not working as expected.

Related comment here : https://github.com/espressif/esptool-js/issues/105#issuecomment-1807002340

PTAL @sdrshnptl