### PR TITLE
Mark enableTracing as optional

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -107,7 +107,7 @@ export interface LoaderOptions {
    * @type {boolean}
    */
   debugLogging?: boolean;
-  enableTracing: boolean;
+  enableTracing?: boolean;
 }
 
 type FlashReadCallback = ((packet: Uint8Array, progress: number, totalSize: number) => void) | null;


### PR DESCRIPTION
The code is already there to handle `LoaderOptions.enableTracing` as undefined but the type did not allow it. This fixes it. 