### PR TITLE
add js extensions use window atob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "buffer": "^6.0.3",
         "pako": "^2.1.0",
         "tslib": "^2.4.1"
       },
@@ -1465,25 +1464,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1533,29 +1513,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -2434,25 +2391,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -4907,11 +4845,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4942,15 +4875,6 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
-      }
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -5601,11 +5525,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "url": "https://github.com/espressif/esptool-js/issues"
   },
   "dependencies": {
-    "buffer": "^6.0.3",
     "pako": "^2.1.0",
     "tslib": "^2.4.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { IEspLoaderTerminal, ESPLoader, FlashOptions, LoaderOptions } from "./esploader";
-export { classicReset, customReset, hardReset, usbJTAGSerialReset, validateCustomResetStringSequence } from "./reset";
-export { ROM } from "./targets/rom";
-export { Transport, SerialOptions } from "./webserial";
+export { IEspLoaderTerminal, ESPLoader, FlashOptions, LoaderOptions } from "./esploader.js";
+export { classicReset, customReset, hardReset, usbJTAGSerialReset, validateCustomResetStringSequence } from "./reset.js";
+export { ROM } from "./targets/rom.js";
+export { Transport, SerialOptions } from "./webserial.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 export { IEspLoaderTerminal, ESPLoader, FlashOptions, LoaderOptions } from "./esploader.js";
-export { classicReset, customReset, hardReset, usbJTAGSerialReset, validateCustomResetStringSequence } from "./reset.js";
+export {
+  classicReset,
+  customReset,
+  hardReset,
+  usbJTAGSerialReset,
+  validateCustomResetStringSequence,
+} from "./reset.js";
 export { ROM } from "./targets/rom.js";
 export { Transport, SerialOptions } from "./webserial.js";

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -1,4 +1,4 @@
-import { Transport } from "./webserial";
+import { Transport } from "./webserial.js";
 
 const DEFAULT_RESET_DELAY = 50;
 

--- a/src/targets/esp32.ts
+++ b/src/targets/esp32.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ROM } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ROM } from "./rom.js";
 import ESP32_STUB from "./stub_flasher/stub_flasher_32.json";
 
 export class ESP32ROM extends ROM {

--- a/src/targets/esp32c2.ts
+++ b/src/targets/esp32c2.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ESP32C3ROM } from "./esp32c3";
+import { ESPLoader } from "../esploader.js";
+import { ESP32C3ROM } from "./esp32c3.js";
 import ESP32C2_STUB from "./stub_flasher/stub_flasher_32c2.json";
 
 export class ESP32C2ROM extends ESP32C3ROM {

--- a/src/targets/esp32c3.ts
+++ b/src/targets/esp32c3.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ROM } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ROM } from "./rom.js";
 import ESP32C3_STUB from "./stub_flasher/stub_flasher_32c3.json";
 
 export class ESP32C3ROM extends ROM {

--- a/src/targets/esp32c6.ts
+++ b/src/targets/esp32c6.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ROM } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ROM } from "./rom.js";
 import ESP32C6_STUB from "./stub_flasher/stub_flasher_32c6.json";
 
 export class ESP32C6ROM extends ROM {

--- a/src/targets/esp32h2.ts
+++ b/src/targets/esp32h2.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ROM } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ROM } from "./rom.js";
 import ESP32H2_STUB from "./stub_flasher/stub_flasher_32h2.json";
 
 export class ESP32H2ROM extends ROM {

--- a/src/targets/esp32s2.ts
+++ b/src/targets/esp32s2.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ROM } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ROM } from "./rom.js";
 import ESP32S2_STUB from "./stub_flasher/stub_flasher_32s2.json";
 
 export class ESP32S2ROM extends ROM {

--- a/src/targets/esp32s3.ts
+++ b/src/targets/esp32s3.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ROM } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ROM } from "./rom.js";
 import ESP32S3_STUB from "./stub_flasher/stub_flasher_32s3.json";
 
 export class ESP32S3ROM extends ROM {

--- a/src/targets/esp8266.ts
+++ b/src/targets/esp8266.ts
@@ -1,5 +1,5 @@
-import { ESPLoader } from "../esploader";
-import { ROM } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ROM } from "./rom.js";
 import ESP8266_STUB from "./stub_flasher/stub_flasher_8266.json";
 
 export class ESP8266ROM extends ROM {

--- a/src/targets/rom.ts
+++ b/src/targets/rom.ts
@@ -1,4 +1,4 @@
-import { ESPLoader } from "../esploader";
+import { ESPLoader } from "../esploader.js";
 
 /**
  * Represents a chip ROM with basic registers field and abstract functions.


### PR DESCRIPTION
Fix #125

Fix #130


Add .js to import to fix issues with Svelte import.

Add function to try to use `window.atob` if available.

PTAL @balloob @hhvrc