### PR TITLE
Fix Broken LICENSE Link in README for Documentation Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ If you are testing the main branch or any Pull Request (PR) artifact you can fol
 
 ## License
 
-The code in this repository is Copyright (c) 2023 Espressif Systems (Shanghai) Co. Ltd. It is licensed under Apache 2.0 license, as described in [LICENSE](LICENSE) file.
+The code in this repository is Copyright (c) 2023 Espressif Systems (Shanghai) Co. Ltd. It is licensed under Apache 2.0 license, as described in [LICENSE](https://github.com/espressif/esptool-js/blob/main/LICENSE) file.


### PR DESCRIPTION
Updated the LICENSE link in the README to fix a broken link issue on the documentation site generated by Jekyll. Changed the link to an absolute URL to ensure it works across different platforms.

Applicable location
https://espressif.github.io/esptool-js/docs/index.html#md:license