### PR TITLE
Support Chrome on Android with web-serial-polyfill in the Example Pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Javascript implementation of esptool
 
-This repository contains a Javascript implementation of [esptool](https://github.com/espressif/esptool), a serial flasher utility for Espressif chips. `esptool-js` is based on [Web Serial API](https://wicg.github.io/serial/) and works in Google Chrome and Microsoft Edge [version 89 or later](https://developer.mozilla.org/en-US/docs/Web/API/Serial#browser_compatibility) browsers.
+This repository contains a Javascript implementation of [esptool](https://github.com/espressif/esptool), a serial flasher utility for Espressif chips. `esptool-js` is based on [Web Serial API](https://wicg.github.io/serial/) and works in Google Chrome and Microsoft Edge [version 89 or later](https://developer.mozilla.org/en-US/docs/Web/API/Serial#browser_compatibility) browsers and Google Chrome on Android [version 61 or later](https://developer.mozilla.org/en-US/docs/Web/API/USB#browser_compatibility) via the [web-serial-polyfill](https://github.com/google/web-serial-polyfill) compatibility layer.
 
 **NOTE:** Unlike the Python-based esptool, `esptool-js` doesn't implement generation of binary images out of ELF files, and doesn't include companion tools similar to [espefuse.py](https://github.com/espressif/esptool/wiki/espefuse) and [espsecure.py](https://github.com/espressif/esptool/wiki/espsecure).
 

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -19,6 +19,7 @@
     "parcel": "^2.8.3",
     "parcel-resolver-ignore": "^2.1.5",
     "rimraf": "^4.1.2",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "web-serial-polyfill": "^1.0.15"
   }
 }

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -24,6 +24,8 @@ const alertDiv = document.getElementById("alertDiv");
 // To optimize use a CDN hosted version like
 // https://unpkg.com/esptool-js@0.2.0/bundle.js
 import { ESPLoader, FlashOptions, LoaderOptions, Transport } from "../../../lib";
+import { serial } from "web-serial-polyfill";
+if (!navigator.serial && navigator.usb) navigator.serial = serial;
 
 declare let Terminal; // Terminal is imported in HTML script
 declare let CryptoJS; // CryptoJS is imported in HTML script


### PR DESCRIPTION
Add Google Chrome on Android [version 61 or later](https://developer.mozilla.org/en-US/docs/Web/API/USB#browser_compatibility) via the [web-serial-polyfill](https://github.com/google/web-serial-polyfill) compatibility layer.

I tested it and it works as expected with Chrome on Android Phones and Tablets.
