### PR TITLE
rm info chip magic, fix bundle atob ref

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,7 +17,7 @@ const config = {
     inlineDynamicImports: true
   },
   plugins: [
-    resolve({ preferBuiltins: false}),
+    resolve({ preferBuiltins: false, mainFields: ["browser"]}),
     commonjs(),
     babel({ exclude: 'node_modules/**', babelHelpers: "runtime", skipPreflightCheck: true }),
     json({ namedExports: false, preferConst: true }),

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -678,7 +678,6 @@ export class ESPLoader {
     if (!detecting) {
       const chipMagicValue = (await this.readReg(0x40001000)) >>> 0;
       this.debug("Chip Magic " + chipMagicValue.toString(16));
-      this.info("Chip Magic " + chipMagicValue.toString(16));
       const chip = await magic2Chip(chipMagicValue);
       if (this.chip === null) {
         throw new ESPError(`Unexpected CHIP magic value ${chipMagicValue}. Failed to autodetect chip type.`);


### PR DESCRIPTION
Rollup was still using Node's version of atob lite (Buffer) in the bundle.js

Also removing chip magic message.