### PR TITLE
Add missing chips features

### DIFF
--- a/src/targets/esp32c3.ts
+++ b/src/targets/esp32c3.ts
@@ -67,8 +67,49 @@ export class ESP32C3ROM extends ROM {
     return desc;
   }
 
-  public async getChipFeatures(loader: ESPLoader) {
-    return ["Wi-Fi", "BLE"];
+  public async getFlashCap(loader: ESPLoader): Promise<number> {
+    const numWord = 3;
+    const block1Addr = this.EFUSE_BASE + 0x044;
+    const addr = block1Addr + 4 * numWord;
+    const registerValue = await loader.readReg(addr);
+    const flashCap = (registerValue >> 27) & 0x07;
+    return flashCap;
+  }
+
+  public async getFlashVendor(loader: ESPLoader): Promise<string> {
+    const numWord = 4;
+    const block1Addr = this.EFUSE_BASE + 0x044;
+    const addr = block1Addr + 4 * numWord;
+    const registerValue = await loader.readReg(addr);
+    const vendorId = (registerValue >> 0) & 0x07;
+    const vendorMap: { [key: number]: string } = {
+      1: "XMC",
+      2: "GD",
+      3: "FM",
+      4: "TT",
+      5: "ZBIT",
+    };
+    return vendorMap[vendorId] || "";
+  }
+
+  public async getChipFeatures(loader: ESPLoader): Promise<string[]> {
+    const features: string[] = ["Wi-Fi", "BLE"];
+
+    const flashMap: { [key: number]: string | null } = {
+      0: null,
+      1: "Embedded Flash 4MB",
+      2: "Embedded Flash 2MB",
+      3: "Embedded Flash 1MB",
+      4: "Embedded Flash 8MB",
+    };
+    const flashCap = await this.getFlashCap(loader);
+    const flashVendor = await this.getFlashVendor(loader);
+    const flash = flashMap[flashCap];
+    const flashDescription = flash !== undefined ? flash : "Unknown Embedded Flash";
+    if (flash !== null) {
+      features.push(`${flashDescription} (${flashVendor})`);
+    }
+    return features;
   }
 
   public async getCrystalFreq(loader: ESPLoader) {

--- a/src/targets/esp32c3.ts
+++ b/src/targets/esp32c3.ts
@@ -68,7 +68,7 @@ export class ESP32C3ROM extends ROM {
   }
 
   public async getChipFeatures(loader: ESPLoader) {
-    return ["Wi-Fi"];
+    return ["Wi-Fi", "BLE"];
   }
 
   public async getCrystalFreq(loader: ESPLoader) {

--- a/src/targets/esp32c6.ts
+++ b/src/targets/esp32c6.ts
@@ -68,7 +68,7 @@ export class ESP32C6ROM extends ROM {
   }
 
   public async getChipFeatures(loader: ESPLoader) {
-    return ["Wi-Fi"];
+    return ["Wi-Fi 6", "BT 5", "IEEE802.15.4"];
   }
 
   public async getCrystalFreq(loader: ESPLoader) {


### PR DESCRIPTION
# What Does This MR Do ?
- It will add missing chip features for `ESP32-C3` and `ESP32-C6` in `getChipFeatures`
- It will add helper functions required by `getChipFeatures` for `ESP32-C3`, `ESP32-S2` and `ESP32-S3`

## Reference's:
- [ESP32-C3](https://github.com/espressif/esptool/blob/eacc94a386267ad39de876f29b7bd1a6823387ae/esptool/targets/esp32c3.py)
- [ESP32-C6](https://github.com/espressif/esptool/blob/eacc94a386267ad39de876f29b7bd1a6823387ae/esptool/targets/esp32c6.py)
- [ESP32-S2](https://github.com/espressif/esptool/blob/eacc94a386267ad39de876f29b7bd1a6823387ae/esptool/targets/esp32s2.py)
- [ESP32-S3](https://github.com/espressif/esptool/blob/eacc94a386267ad39de876f29b7bd1a6823387ae/esptool/targets/esp32s3.py)