### PR TITLE
disconnect btn not shown upon connect error

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains a Javascript implementation of [esptool](https://github
 
 `yarn add --save esptool-js`
 
-Check an example project [here](./examples/typescript).
+Check an example project [here](https://github.com/espressif/esptool-js/tree/main/examples/typescript).
 
 **Nightly builds** for <a href="https://nightly.link/espressif/esptool-js/workflows/ci/main">ESPTOOL-JS</a>
 

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -85,12 +85,11 @@ const espLoaderTerminal = {
 };
 
 connectButton.onclick = async () => {
-  if (device === null) {
-    device = await serialLib.requestPort({});
-    transport = new Transport(device, true);
-  }
-
   try {
+    if (device === null) {
+      device = await serialLib.requestPort({});
+      transport = new Transport(device, true);
+    }
     const flashOptions = {
       transport,
       baudrate: parseInt(baudrates.value),
@@ -103,22 +102,21 @@ connectButton.onclick = async () => {
 
     // Temporarily broken
     // await esploader.flashId();
+    console.log("Settings done for :" + chip);
+    lblBaudrate.style.display = "none";
+    lblConnTo.innerHTML = "Connected to device: " + chip;
+    lblConnTo.style.display = "block";
+    baudrates.style.display = "none";
+    connectButton.style.display = "none";
+    disconnectButton.style.display = "initial";
+    traceButton.style.display = "initial";
+    eraseButton.style.display = "initial";
+    filesDiv.style.display = "initial";
+    consoleDiv.style.display = "none";
   } catch (e) {
     console.error(e);
     term.writeln(`Error: ${e.message}`);
   }
-
-  console.log("Settings done for :" + chip);
-  lblBaudrate.style.display = "none";
-  lblConnTo.innerHTML = "Connected to device: " + chip;
-  lblConnTo.style.display = "block";
-  baudrates.style.display = "none";
-  connectButton.style.display = "none";
-  disconnectButton.style.display = "initial";
-  traceButton.style.display = "initial";
-  eraseButton.style.display = "initial";
-  filesDiv.style.display = "initial";
-  consoleDiv.style.display = "none";
 };
 
 traceButton.onclick = async () => {


### PR DESCRIPTION
## Description

Fix #165 
Fix #173 

Buttons should not be updated when there is a failed connection error in the Typescript live example.

## Testing

Clone this branch and run `npm run dev` within `examples/typescript`. This will create a local server running at http://localhost:1234
1. Connect on 1 tab. Connection should be successful.
2. Open a new tab and try to connect. Connection should fail but buttons like `disconnect` should not be shown.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
