### PR TITLE
Implement no_reset mode

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -625,7 +625,9 @@ export class ESPLoader {
    */
   async _connectAttempt(mode = "default_reset", resetStrategy: ResetStrategy): Promise<string> {
     this.debug("_connect_attempt " + mode);
-    await resetStrategy.reset();
+    if (mode !== "no_reset") {
+      await resetStrategy.reset();
+    }
     const waitingBytes = this.transport.inWaiting();
     const readBytes = await this.transport.newRead(waitingBytes > 0 ? waitingBytes : 1, this.DEFAULT_TIMEOUT);
 
@@ -785,10 +787,10 @@ export class ESPLoader {
             throw new ESPError(
               `Software loader is resident at 0x${stubStart.toString(16).padStart(8, "0")}-0x${stubEnd
                 .toString(16)
-                .padStart(8, "0")}. 
+                .padStart(8, "0")}.
             Can't load binary at overlapping address range 0x${loadStart.toString(16).padStart(8, "0")}-0x${loadEnd
                 .toString(16)
-                .padStart(8, "0")}. 
+                .padStart(8, "0")}.
             Either change binary loading address, or use the no-stub option to disable the software loader.`,
             );
           }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

The no_reset option is very useful for for doing passthrough updates as the reset functionality causes the passed-through board to not respond. I added the no_reset feature in the simplest way possible (just not calling reset()), though in future updates, feel free to change it.

## Related

Fixes #178. Also, a partial fix for https://github.com/adafruit/Adafruit_WebSerial_ESPTool/issues/321.

## Testing

I tested this using a local version of https://github.com/adafruit/Adafruit_WebSerial_ESPTool. With this fix alone, it fails on the first attempt and then works on subsequent attempts. I will have another PR for that repo (related to our passthrough code) which makes it work consistently.

For hardware, I am using a Feather M4 and following the instructions in https://learn.adafruit.com/upgrading-esp32-firmware/upgrade-external-esp32-airlift-firmware-2.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
