### PR TITLE
Bugfix/jtag monitor

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -134,11 +134,13 @@ const resetFunction = async () => {
   if (!transport) {
     return;
   }
-  if ((navigator as any).serial !== undefined) { // WebSerial
+  if ((navigator as any).serial !== undefined) {
+    // WebSerial
     await transport.setDTR(false);
     await transport.sleep(100);
     await transport.setDTR(true);
-  } else { // WebUSB polyfill
+  } else {
+    // WebUSB polyfill
     new UsbJtagSerialReset(transport).reset();
     await transport.sleep(100);
     // can also use SerialReset twice, but then the chip gets reset 1.5 times
@@ -149,7 +151,7 @@ const resetFunction = async () => {
     await transport.setRTS(false);
   }
 };
-resetButton.onclick = resetFunction
+resetButton.onclick = resetFunction;
 
 eraseButton.onclick = async () => {
   eraseButton.disabled = true;


### PR DESCRIPTION
Update reset function in example code with code from https://github.com/espressif/vscode-esp-idf-web-extension/pull/21 

Reset function on Console reset might not work on some JTAG devices. The code from @archef2000 could fix the issue here.

Also add reset on console start so user doesn't need to manually reset every time.

## Description

Fix #171


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
