### PR TITLE
Add panic address decoder and monitor input

### DIFF
--- a/examples/typescript/src/index.html
+++ b/examples/typescript/src/index.html
@@ -86,6 +86,10 @@
                 <input class="btn btn-info" type="button" id="consoleStartButton" value="Start" />
                 <input class="btn btn-info" type="button" id="consoleStopButton" value="Stop" />
                 <input class="btn btn-info" type="button" id="resetButton" value="Reset" />
+                
+                <br><br>
+
+                <input class="btn btn-info btn-sm" type="file" id="addElfFile" value="Add Elf files" accept=".elf" multiple />
                 <hr/>
             </div>
             <div id="terminal"></div>

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -19,13 +19,14 @@ const lblConsoleFor = document.getElementById("lblConsoleFor");
 const lblConnTo = document.getElementById("lblConnTo");
 const table = document.getElementById("fileTable") as HTMLTableElement;
 const alertDiv = document.getElementById("alertDiv");
+const addElfFileButton = document.getElementById("addElfFile") as HTMLInputElement;
 
 const debugLogging = document.getElementById("debugLogging") as HTMLInputElement;
 
 // This is a frontend example of Esptool-JS using local bundle file
 // To optimize use a CDN hosted version like
 // https://unpkg.com/esptool-js@0.5.0/bundle.js
-import { ESPLoader, FlashOptions, LoaderOptions, Transport } from "../../../lib";
+import { ESPLoader, FlashOptions, LoaderOptions, Transport, AddressDecoder } from "../../../lib";
 import { serial } from "web-serial-polyfill";
 
 const serialLib = !navigator.serial && navigator.usb ? serial : navigator.serial;
@@ -71,6 +72,27 @@ function handleFileSelect(evt) {
 
   reader.readAsBinaryString(file);
 }
+
+/**
+ * File reader handler to read given local files.
+ * @param {Event} evt File Select event
+ */
+async function handleElfFileSelect(evt) {
+  const files = evt.target.files;
+
+  if (files.length === 0) return;
+  // get all files as an array of arrayBuffers
+  const elfFileBuffers = await Promise.all(Array.from(files).map((file: File) => file.arrayBuffer()));
+  console.log(files, elfFileBuffers);
+  await AddressDecoder.update(elfFileBuffers);
+}
+
+addElfFileButton.onchange = handleElfFileSelect;
+
+const encoder = new TextEncoder();
+export const stringToUInt8Array = function (textString: string) {
+  return encoder.encode(textString);
+};
 
 const espLoaderTerminal = {
   clean() {
@@ -237,6 +259,15 @@ consoleStartButton.onclick = async () => {
     device = await serialLib.requestPort({});
     transport = new Transport(device, true);
   }
+  term.onData((data: string) => {
+    const writer = transport.device.writable?.getWriter();
+    if (writer) {
+      writer.write(stringToUInt8Array(data));
+      writer.releaseLock();
+    } else {
+      console.error("Unable to write to serial port");
+    }
+  });
   lblConsoleFor.style.display = "block";
   lblConsoleBaudrate.style.display = "none";
   consoleBaudrates.style.display = "none";
@@ -248,6 +279,10 @@ consoleStartButton.onclick = async () => {
   await transport.connect(parseInt(consoleBaudrates.value));
   isConsoleClosed = false;
 
+  const output = (line: string) => {
+    term.writeln(line);
+  };
+  let lastLine = "";
   while (true && !isConsoleClosed) {
     const readLoop = transport.rawRead();
     const { value, done } = await readLoop.next();
@@ -255,12 +290,24 @@ consoleStartButton.onclick = async () => {
     if (done || !value) {
       break;
     }
-    term.write(value);
+
+    const valueStr = uInt8ArrayToString(value);
+    lastLine += valueStr;
+    const splitLine = lastLine.split("\r\n");
+    while (splitLine.length > 1) {
+      const line = splitLine.shift();
+      if (line !== undefined) {
+        AddressDecoder.parser(line, output);
+      }
+    }
+    lastLine = splitLine[0];
   }
   console.log("quitting console");
 };
 
 consoleStopButton.onclick = async () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  term.onData = () => {};
   isConsoleClosed = true;
   if (transport) {
     await transport.disconnect();
@@ -276,6 +323,19 @@ consoleStopButton.onclick = async () => {
   programDiv.style.display = "initial";
   cleanUp();
 };
+
+/**
+ * Convert a Uint8Array to a string
+ * @param {Uint8Array} fileBuffer Uint8Array to convert
+ * @returns {string} String representation of the Uint8Array
+ */
+export function uInt8ArrayToString(fileBuffer: Uint8Array): string {
+  let fileBufferString = "";
+  for (let i = 0; i < fileBuffer.length; i++) {
+    fileBufferString += String.fromCharCode(fileBuffer[i]);
+  }
+  return fileBufferString;
+}
 
 /**
  * Validate the provided files images and offset to see if they're valid.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "atob-lite": "^2.0.0",
+        "jselftools": "^0.2.2",
         "pako": "^2.1.0",
         "tslib": "^2.4.1"
       },
@@ -2523,6 +2524,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/jselftools": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/jselftools/-/jselftools-0.2.2.tgz",
+      "integrity": "sha512-H535wvUmAxOw+9FXok7BIYHO4MAKfx71Rw3bKgYlfV2Q9CYXC1aKhTQC1R7q358TfwktIYZSzjoqSecSOnnPPg==",
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -5579,6 +5586,11 @@
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
       "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true
+    },
+    "jselftools": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/jselftools/-/jselftools-0.2.2.tgz",
+      "integrity": "sha512-H535wvUmAxOw+9FXok7BIYHO4MAKfx71Rw3bKgYlfV2Q9CYXC1aKhTQC1R7q358TfwktIYZSzjoqSecSOnnPPg=="
     },
     "jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "atob-lite": "^2.0.0",
+    "jselftools": "^0.2.2",
     "pako": "^2.1.0",
     "tslib": "^2.4.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export { LoaderOptions } from "./types/loaderOptions.js";
 export { FlashOptions } from "./types/flashOptions.js";
 export { IEspLoaderTerminal } from "./types/loaderTerminal.js";
 export { Before, After } from "./types/resetModes.js";
+export { AddressDecoder } from "./panic_decoder";

--- a/src/panic_decoder.ts
+++ b/src/panic_decoder.ts
@@ -41,9 +41,10 @@ export class AddressDecoder {
         this.intervals.push({
           start: interval[0],
           end: interval[1],
-          elfIdx: i++,
+          elfIdx: i,
         });
       }
+      i++;
     }
     this.intervals.sort((a, b) => a.start - b.start);
   }
@@ -144,10 +145,10 @@ export class AddressDecoder {
     const { directory, filename, lineNumber, column, discriminator } = line;
     if (discriminator > 0) {
       // eslint-disable-next-line prettier/prettier
-      outputFn("0x" + hexAddress + ": " + directory + "/" + fnName + " at " + filename + ":" + lineNumber + ":" + column + " (discriminator " + discriminator + ")");
+      outputFn("0x" + hexAddress + ": " + fnName + " at " + directory + "/" + filename + ":" + lineNumber + ":" + column + " (discriminator " + discriminator + ")");
     } else {
       // eslint-disable-next-line prettier/prettier
-      outputFn("0x" + hexAddress + ": " + directory + "/" + fnName + " at " + filename + ":" + lineNumber + ":" + column);
+      outputFn("0x" + hexAddress + ": " + fnName + " at " + directory + "/" + filename + ":" + lineNumber + ":" + column);
     }
     return true;
   }
@@ -172,7 +173,7 @@ export class AddressDecoder {
       return;
     } else if (line.includes("ELF file SHA256:")) {
       const hash = this.extractHash(line);
-      if (hash) {
+      if (hash && this.sha) {
         outputFn(line);
         if (!this.sha.startsWith(hash)) {
           parserOutput(

--- a/src/panic_decoder.ts
+++ b/src/panic_decoder.ts
@@ -1,0 +1,237 @@
+import ELFFile, { CompileUnit, Die, DWARFInfo } from "jselftools";
+import { AddressLocation } from "./types/decoder";
+import { getSHA256 } from "./util";
+
+const ADDRESS_RE = /0x[0-9a-f]{8}/gi;
+
+interface ParsedElfFile {
+  dwarfinfo: DWARFInfo;
+  subprograms: Die[];
+  intervals: number[][];
+  sha: string;
+}
+
+interface Interval {
+  start: number;
+  end: number;
+  elfIdx: number;
+}
+
+/**
+ * Class to check and decode an address
+ */
+export class AddressDecoder {
+  private static elfFiles: ParsedElfFile[] = [];
+  private static sha = "";
+  private static intervals: Interval[] = [];
+
+  /**
+   * load elf files and filter for faster address decoding
+   * @param {ArrayBufferLike[]} elfFileBuffers elf file buffers
+   * @param appIdx the index in the {@link elfFileBuffers} array to use for the sha
+   */
+  static async update(elfFileBuffers: ArrayBufferLike[], appIdx = 0): Promise<void> {
+    for (const elfFileBuffer of elfFileBuffers) {
+      this.elfFiles.push(await this.loadElfFile(elfFileBuffer));
+    }
+    this.sha = this.elfFiles[appIdx].sha;
+    let i = 0;
+    for (const elfFile of this.elfFiles) {
+      for (const interval of elfFile.intervals) {
+        this.intervals.push({
+          start: interval[0],
+          end: interval[1],
+          elfIdx: i++,
+        });
+      }
+    }
+    this.intervals.sort((a, b) => a.start - b.start);
+  }
+
+  /**
+   * load elf file and parse it
+   * @param {ArrayBufferLike} elfFileBuffer elf file buffer
+   * @returns {Promise<ParsedElfFile>} parsed elf file
+   */
+  static async loadElfFile(elfFileBuffer: ArrayBufferLike): Promise<ParsedElfFile> {
+    const sha = await getSHA256(elfFileBuffer);
+    const elffile = new ELFFile(elfFileBuffer);
+    const dwarfinfo = elffile.get_dwarf_info();
+    const subprograms: Die[] = [];
+
+    for (const CU of dwarfinfo.get_CUs()) {
+      for (const die of CU.dies) {
+        if (die.has_children) {
+          for (const child of die.children) {
+            if (child.tag === "DW_TAG_subprogram") {
+              const highPc = child.attributes["DW_AT_high_pc"];
+              const lowPc = child.attributes["DW_AT_low_pc"];
+              if (lowPc && lowPc.value > 0 && highPc.value > 0) {
+                subprograms.push(child);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const intervals: number[][] = [];
+    for (const section of elffile.body.sections) {
+      if (section.flags["execinstr"]) {
+        const addr = section.addr;
+        intervals.push([Number(addr), Number(addr) + Number(section.size)]);
+      }
+    }
+    intervals.sort((a, b) => a[0] - b[0]);
+    return {
+      intervals,
+      sha,
+      dwarfinfo,
+      subprograms,
+    };
+  }
+
+  /**
+   * get the index of the elf file that contains the address
+   * @param address resolves an address to an elf file index
+   * @returns the elf index of the elf file that contains the address or -1 if no elf file contains the address
+   */
+  static getElfIdx(address: number): number | undefined {
+    for (const { start, end, elfIdx } of this.intervals) {
+      if (start > address) {
+        break;
+      } else if (start <= address && address < end) {
+        return elfIdx;
+      }
+    }
+    return undefined;
+  }
+
+  static getDecodedAddress(address: number): { fnName: string; line: AddressLocation | undefined } | undefined {
+    const addressElfIdx = this.getElfIdx(address);
+    if (addressElfIdx === undefined) {
+      return undefined;
+    }
+
+    const subprograms = this.elfFiles[addressElfIdx].subprograms;
+    for (const subprogram of subprograms) {
+      const lowPc = subprogram.attributes["DW_AT_low_pc"].value;
+      const highPc = subprogram.attributes["DW_AT_high_pc"].value + lowPc;
+      if (address >= lowPc && address < highPc) {
+        const line = this.checkLineprogram(subprogram.cu, address, addressElfIdx);
+        return {
+          fnName: subprogram.attributes["DW_AT_name"].value,
+          line,
+        };
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * decode the address and call the output function with the decoded address
+   * @param address the address to decode
+   * @param outputFn the function to call with the decoded address
+   * @returns true if the address was decoded, false otherwise
+   */
+  static decode(address: number, outputFn: (message: string) => void): boolean {
+    const decodedAddress = this.getDecodedAddress(address);
+    if (decodedAddress === undefined || decodedAddress.line === undefined) {
+      return false;
+    }
+    const hexAddress = address.toString(16);
+    const { fnName, line } = decodedAddress;
+    const { directory, filename, lineNumber, column, discriminator } = line;
+    if (discriminator > 0) {
+      // eslint-disable-next-line prettier/prettier
+      outputFn("0x" + hexAddress + ": " + directory + "/" + fnName + " at " + filename + ":" + lineNumber + ":" + column + " (discriminator " + discriminator + ")");
+    } else {
+      // eslint-disable-next-line prettier/prettier
+      outputFn("0x" + hexAddress + ": " + directory + "/" + fnName + " at " + filename + ":" + lineNumber + ":" + column);
+    }
+    return true;
+  }
+
+  static parser(line: string, outputFn: (message: string) => void) {
+    const parserOutput = (line: string) => {
+      outputFn("\x1b[33m-- " + line + "\x1b[0m");
+    };
+    if (ADDRESS_RE.test(line)) {
+      outputFn(line);
+      const match = line.match(ADDRESS_RE) ?? [];
+      const addrMap = match.map((hex) => parseInt(hex, 16));
+      let decoded = false;
+      for (const addr of addrMap) {
+        if (this.decode(addr, parserOutput)) {
+          decoded = true;
+        }
+      }
+      if (decoded) {
+        outputFn("");
+      }
+      return;
+    } else if (line.includes("ELF file SHA256:")) {
+      const hash = this.extractHash(line);
+      if (hash) {
+        outputFn(line);
+        if (!this.sha.startsWith(hash)) {
+          parserOutput(
+            "Warning: Checksum mismatch between flashed and built applications. Checksum of built application is " +
+              this.sha,
+          );
+        }
+        return;
+      }
+    }
+    outputFn(line);
+  }
+
+  static extractHash(line: string): string {
+    const pattern = /(?:I \(\d+\) cpu_start: )?ELF file SHA256:\s+(\w+)/;
+    const match = line.match(pattern);
+    return match ? match[1] : "";
+  }
+
+  private static checkLineprogram(
+    cu: CompileUnit,
+    address: number,
+    elfIdx: number | undefined,
+  ): AddressLocation | undefined {
+    if (elfIdx === undefined) {
+      elfIdx = this.getElfIdx(address);
+      if (elfIdx === undefined) {
+        return undefined;
+      }
+    }
+    const dwarfinfo = this.elfFiles[elfIdx].dwarfinfo;
+
+    const lineprog = dwarfinfo.line_program_for_CU(cu);
+    if (!lineprog) {
+      return undefined;
+    }
+    const delta = lineprog.header.version < 5 ? 1 : 0;
+    let prevstate = null;
+    for (const entry of lineprog.get_entries()) {
+      if (entry.state === null) {
+        continue;
+      }
+      if (prevstate && prevstate.address <= address && address < entry.state.address) {
+        const filename = lineprog.header.file_entry[prevstate.file - delta];
+        const directory = lineprog.header.include_directory[filename.dir_index - delta];
+        return {
+          directory,
+          filename: filename.name,
+          lineNumber: prevstate.line,
+          column: prevstate.column,
+          discriminator: prevstate.discriminator,
+        };
+      }
+      if (entry.state.end_sequence) {
+        prevstate = null;
+      } else {
+        prevstate = entry.state;
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/types/decoder.ts
+++ b/src/types/decoder.ts
@@ -1,0 +1,7 @@
+export interface AddressLocation {
+  directory: string;
+  filename: string;
+  lineNumber: number;
+  column: number;
+  discriminator: number;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,3 +16,15 @@ export function padTo(data: Uint8Array, alignment: number, padCharacter = 0xff):
   }
   return data;
 }
+
+/**
+ * get the SHA256 hash of an ArrayBuffer
+ * @param {ArrayBufferLike} arrayBuffer ArrayBuffer to hash
+ * @returns {string} SHA256 hash of the ArrayBuffer
+ */
+export async function getSHA256(arrayBuffer: ArrayBufferLike): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  return hashHex;
+}


### PR DESCRIPTION
## Description
* Make panic address decoder @brianignacio5 said in https://github.com/espressif/vscode-esp-idf-web-extension/pull/26#issuecomment-2775181952
* Implement it in the live example
* Add console input in the example

## Related
https://github.com/espressif/vscode-esp-idf-web-extension/pull/26#

## Testing
OS: Windows
Browser: Chrome
* run console with and without elf file(s)

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Git history is clean — commits are squashed to the minimum necessary.
