### PR TITLE
Fix being unable to flash certain C5 chips

### DIFF
--- a/src/targets/esp32c5.ts
+++ b/src/targets/esp32c5.ts
@@ -47,7 +47,7 @@ export class ESP32C5ROM extends ESP32C6ROM {
 
   public XTAL_CLK_DIVIDER = 1;
 
-  public UARTDEV_BUF_NO = 0x4085F514; // Variable in ROM .bss which indicates the port in use
+  public UARTDEV_BUF_NO = 0x4085f514; // Variable in ROM .bss which indicates the port in use
 
   // Magic value for ESP32C5
   public CHIP_DETECT_MAGIC_VALUE = [0x1101406f, 0x63e1406f, 0x5fd1406f];


### PR DESCRIPTION
## Description

Could not flash my C5 with esptool-js and wanted to fix it for myself and other customers.


## Related

https://github.com/espressif/esptool/commit/81bdb76b10550e8f0fb87415afe75752fe6a2ea9
https://github.com/espressif/esptool/pull/1140

## Testing

flashed all my c5 variants to make sure it didn't regress compatibility

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
