### PR TITLE
feat: implement writeFlash for the uncompressed (compress: false) path

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -1580,7 +1580,7 @@ export class ESPLoader {
         this.debug("Write loop " + address + " " + seq + " " + blocks);
         this.info(
           "Writing at 0x" +
-            (address + totalLenUncompressed).toString(16) +
+            (address + (options.compress ? totalLenUncompressed : bytesSent)).toString(16) +
             "... (" +
             Math.floor((100 * (seq + 1)) / blocks) +
             "%)",
@@ -1607,7 +1607,23 @@ export class ESPLoader {
             timeout = blockTimeout;
           }
         } else {
-          throw new ESPError("Yet to handle Non Compressed writes");
+          // Last block is padded to FLASH_WRITE_SIZE with 0xFF, matching esptool.py.
+          let dataToSend = block;
+          if (block.length < this.FLASH_WRITE_SIZE) {
+            dataToSend = new Uint8Array(this.FLASH_WRITE_SIZE).fill(0xff);
+            dataToSend.set(block);
+          }
+          let blockTimeout = 3000;
+          if (this.timeoutPerMb(this.ERASE_WRITE_TIMEOUT_PER_MB, dataToSend.length) > 3000) {
+            blockTimeout = this.timeoutPerMb(this.ERASE_WRITE_TIMEOUT_PER_MB, dataToSend.length);
+          }
+          if (this.IS_STUB === false) {
+            timeout = blockTimeout;
+          }
+          await this.flashBlock(dataToSend, seq, timeout);
+          if (this.IS_STUB) {
+            timeout = blockTimeout;
+          }
         }
         bytesSent += block.length;
         imageOffset += blockSize;
@@ -1635,6 +1651,8 @@ export class ESPLoader {
             t / 1000 +
             " seconds.",
         );
+      } else {
+        this.info("Wrote " + bytesSent + " bytes at 0x" + address.toString(16) + " in " + t / 1000 + " seconds.");
       }
       if (calcmd5) {
         this.info("File  md5: " + calcmd5);


### PR DESCRIPTION
# feat: implement writeFlash for the uncompressed (compress: false) path

Branch: `feat/uncompressed-writeflash`
File touched: `src/esploader.ts`
Diff: +20 / −2, one file

## Summary

`writeFlash({ compress: false })` previously threw
`ESPError("Yet to handle Non Compressed writes")` — an in-source TODO that
had never been implemented. This PR fills in the branch using the existing
`flashBegin` / `flashBlock` / `flashFinish` primitives, mirroring the
compressed code path and matching esptool.py.

## Motivation

The low-level primitives required for an uncompressed flash were already
present and tested in the codebase. Only the high-level orchestration inside
`writeFlash` was missing, which made `compress: false` unreachable. Closing
this TODO is parity with esptool.py, where uncompressed and compressed
write paths are both first-class.

## Changes

In `writeFlash`, inside the per-block `while` loop:

- The `} else { throw new ESPError("Yet to handle Non Compressed writes"); }`
  branch is replaced with a real implementation:
  - The final short block is padded to `FLASH_WRITE_SIZE` with `0xFF`,
    matching esptool.py (which appends `b"\xff" * (FLASH_WRITE_SIZE - len(block))`).
  - Per-block timeout follows the same `ERASE_WRITE_TIMEOUT_PER_MB` /
    `IS_STUB` rule as the compressed branch.
  - `flashBlock(block, seq, timeout)` is called for each block.
- The in-loop `Writing at 0x...` progress log is updated to use `bytesSent`
  for the uncompressed branch (the compressed branch still uses
  `totalLenUncompressed`, because the compressed `bytesSent` is in
  compressed-bytes and would mislead).
- A symmetrical `Wrote N bytes at 0x... in T seconds.` summary log is
  emitted for uncompressed runs, paralleling the existing compressed-mode
  summary.

All other call-site code is unchanged: `flashBegin(uncsize, address)` was
already invoked when `compress=false`, `flashFinish(false, timeout)` was
already invoked from the post-loop block, and `reportProgress` /
`calculateMD5Hash` / `eraseAll` are common to both branches.

## Reference

esptool master, `esptool/cmds.py` (`write_flash`, uncompressed branch):

```python
while written < uncsize:
    block = image[written:written + esp.FLASH_WRITE_SIZE]
    block = block + b"\xff" * (esp.FLASH_WRITE_SIZE - len(block))
    esp.flash_block(block, seq, timeout=block_timeout)
    written += len(block)
    seq += 1
```

The TypeScript port preserves the same block size, the same `0xFF` padding,
and the same `flashBlock` invocation.

## Testing

- `npm run build`, `npm run lint` — both clean. Lint baseline (24 pre-existing
  warnings in unrelated files, 0 errors) is preserved.
- Manual smoke test through `examples/typescript` (Web Serial → ESP32-S3
  DevKitC):
  - `writeFlash({ compress: false })` now completes end-to-end (previously
    threw immediately).
  - `writeFlash({ compress: true })` is byte-identical to current `main`
    behaviour at the user level (verified by console-log inspection).
  - `calculateMD5Hash` post-flash check returns identical hashes for the
    two modes against the same image.

## Compatibility

- No public API change. `FlashOptions.compress` already existed; this PR
  makes the `false` value work.
- No new constants, no new options.
