### PR TITLE
Avoid TypeError when debug logging a short flashDeflBlock payload

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -932,12 +932,8 @@ export class ESPLoader {
 
     const checksum = this.checksum(data);
     this.debug(
-      "flash_defl_block " +
-        (data.length > 0 ? data[0].toString(16) : "") +
-        " " +
-        (data.length > 1 ? data[1].toString(16) : ""),
+      `flash_defl_block ${Array.from(data.slice(0, 2)).map(b => b.toString(16)).join(" ")}`
     );
-
     await this.checkCommand(
       "write compressed data to flash after seq " + seq,
       this.ESP_FLASH_DEFL_DATA,

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -931,7 +931,12 @@ export class ESPLoader {
     pkt = this._appendArray(pkt, data);
 
     const checksum = this.checksum(data);
-    this.debug("flash_defl_block " + data[0].toString(16) + " " + data[1].toString(16));
+    this.debug(
+      "flash_defl_block " +
+        (data.length > 0 ? data[0].toString(16) : "") +
+        " " +
+        (data.length > 1 ? data[1].toString(16) : ""),
+    );
 
     await this.checkCommand(
       "write compressed data to flash after seq " + seq,


### PR DESCRIPTION
## Description

This PR fixes a potential `TypeError` in `flashDeflBlock()` when the payload contains fewer than two bytes.

The existing debug logging assumes that `data[0]` and `data[1]` are always present:

```ts
this.debug("flash_defl_block " + data[0].toString(16) + " " + data[1].toString(16));
```

However, the final compressed block may be shorter than two bytes. In that case, accessing `data[1].toString(16)` throws:

```
TypeError: Cannot read properties of undefined (reading 'toString')
```

The flash operation aborts before the packet is sent.

This change makes the debug output resilient to short payloads by formatting only the bytes that are actually present.

This does not change flashing behavior, packet contents, timing, or protocol handling. Only the debug string generation is affected.

## Related

No related issue.

Observed while debugging a failed compressed flash operation where the final compressed block contained only a single byte.

## Testing

Tested locally using a firmware image that consistently triggered:

```
TypeError: Cannot read properties of undefined (reading 'toString')
```

before the change.

After applying this patch, the same image flashes successfully and the operation completes without exceptions.

Additionally verified that normal flashing continues to work unchanged with larger compressed blocks.
