### PR TITLE
Bugfix: Improve connection reliability and serial reader cleanup

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -637,10 +637,12 @@ export class ESPLoader {
       const chipMagicValue = (await this.readReg(this.CHIP_DETECT_MAGIC_REG_ADDR)) >>> 0;
       this.debug("Chip Magic " + chipMagicValue.toString(16));
       const chip = await magic2Chip(chipMagicValue);
-      if (typeof this.chip === null) {
-        throw new ESPError(`Unexpected CHIP magic value ${chipMagicValue}. Failed to autodetect chip type.`);
+      if (chip === null) {
+        throw new ESPError(
+          `Unexpected CHIP magic value 0x${chipMagicValue.toString(16)}. Failed to autodetect chip type.`,
+        );
       } else {
-        this.chip = chip as ROM;
+        this.chip = chip;
       }
     }
   }

--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -399,7 +399,12 @@ class Transport {
 
   /**
    * Read from serial device without SLIP formatting. Calls onData for each chunk.
-   * Stops when isClosed() returns true or the stream ends/errors.
+   * Stops when isClosed() returns true, the stream ends/errors, or disconnect() is called.
+   *
+   * The reader is stored on the instance so that disconnect() can cancel a pending
+   * read: isClosed() is only evaluated after each chunk arrives, so on an idle
+   * device a function-local reader would keep the stream locked forever and make
+   * disconnect() block in waitForUnlock().
    * @param {Function} onData Callback for each chunk of data read
    * @param {Function} isClosed Function that returns true when reading should stop (e.g. when console is closed)
    */
@@ -410,6 +415,7 @@ class Transport {
         return;
       }
       reader = this.device.readable.getReader();
+      this.reader = reader;
       while (!isClosed()) {
         const { value, done } = await reader.read();
         if (done || !value) break;
@@ -428,6 +434,9 @@ class Transport {
       }
     } finally {
       reader?.releaseLock();
+      if (this.reader === reader) {
+        this.reader = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR improves connection reliability by addressing issues in chip detection and the Web Serial reader lifecycle.

### Problem

Two issues were affecting connection stability and error handling:

* An invalid null check during chip autodetection prevented unknown chip magic values from being detected early, resulting in a later failure during chip initialization with a less actionable error.
* `rawRead()` used a function-local serial reader, preventing `disconnect()` from cancelling a pending read on an idle device. This could leave the serial stream locked and cause `disconnect()` to block while waiting for the reader lock to be released.

### Changes

* Fix chip autodetection by validating the resolved chip instead of an invalid null check, and throw an `ESPError` with the unexpected chip magic value (in hexadecimal) when autodetection fails.
* Store the active serial reader on the transport so `disconnect()` can cancel pending `rawRead()` operations on idle devices.
* Preserve reader ownership during cleanup to ensure a late-finishing `rawRead()` does not release a reader already acquired by `readLoop()`.

## Related

N/A

## Testing

* Verified successful connection with supported chips.
* Verified `disconnect()` no longer blocks when `rawRead()` is pending on an idle device.
* Verified normal `readLoop()` operation remains unaffected after the reader lifecycle changes.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

* [x] 🚨 This PR does not introduce breaking changes.
* [x] Code is well-commented, especially in complex areas.
* [x] All CI checks (GH Actions) pass.
* [x] Git history is clean — commits are squashed to the minimum necessary