### PR TITLE
Compressed writeFlash fails mid-image over native USB (FLASH_WRITE_SIZE exceeds USB_RAM_BLOCK)

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -191,7 +191,7 @@ export class ESPLoader {
     // larger blocks overflow the flasher stub's USB buffer and the stub
     // answers 0xC9 "Too much data" mid-write. Native-USB Espressif links
     // are recognizable by the Web Serial USB vendor id.
-    const usbInfo = this.transport.device.getInfo?.();
+    const usbInfo = options.transport.device.getInfo?.();
     if (usbInfo && usbInfo.usbVendorId === 0x303a) {
       this.FLASH_WRITE_SIZE = 0x800;
     }

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -186,6 +186,16 @@ export class ESPLoader {
     this.IS_STUB = false;
     this.FLASH_WRITE_SIZE = 0x4000;
 
+    // esptool.py caps the write block at USB_RAM_BLOCK (0x800) for chips
+    // connected through their native USB (USB-Serial-JTAG / USB-OTG):
+    // larger blocks overflow the flasher stub's USB buffer and the stub
+    // answers 0xC9 "Too much data" mid-write. Native-USB Espressif links
+    // are recognizable by the Web Serial USB vendor id.
+    const usbInfo = this.transport.device.getInfo?.();
+    if (usbInfo && usbInfo.usbVendorId === 0x303a) {
+      this.FLASH_WRITE_SIZE = 0x800;
+    }
+
     this.transport = options.transport;
     this.baudrate = options.baudrate;
     this.resetConstructors = {


### PR DESCRIPTION
Fixes #255

`FLASH_WRITE_SIZE` is hardcoded to `0x4000`. esptool.py caps it at `USB_RAM_BLOCK` (0x800) for chips connected through native USB (USB-Serial-JTAG / USB-OTG), because the flasher stub's USB buffer can't absorb 16 KB blocks. Over Web Serial on an ESP32-S3's native USB, a compressed write of a 1.3 MB image fails deterministically at ~75 %:

```
Failed to write compressed data to flash after seq 42 failed with status 201,0
```

(0xC9 = stub error "Too much data".)

## Fix

Cap `FLASH_WRITE_SIZE` at 0x800 when the Web Serial port reports the Espressif USB vendor id (`0x303a`), the same condition under which esptool.py applies `USB_RAM_BLOCK`. USB-UART bridges (CP210x, CH340, …) keep the 16 KB default.

## Testing

- [ ] ESP32-S3 native USB (USB-Serial/JTAG), compressed 1.3 MB write previously failing at seq 42
- [ ] USB-UART bridge regression check