### PR TITLE
Drain stale transport input before sending a command

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -417,6 +417,12 @@ export class ESPLoader {
     timeout = this.DEFAULT_TIMEOUT,
   ): Promise<[number, Uint8Array]> {
     if (op != null) {
+      // Discard any stale input before sending: leftover bytes (e.g. an
+      // extra ack packet from a fire-and-forget write) would otherwise be
+      // read as this command's response, desyncing the protocol — observed
+      // as flashMd5sum/readFlash returning constant junk right after a
+      // completed writeFlash.
+      this.transport.flushInput();
       if (this.transport.tracing) {
         this.transport.trace(
           `command op:0x${op.toString(16).padStart(2, "0")} data len=${data.length} wait_response=${


### PR DESCRIPTION
Fixes #256 

## Problem

`command()` never clears pending transport input before writing a request. A leftover packet (e.g. a trailing ack from a fire-and-forget write) is then read as the next command's response, desyncing the protocol. Observed on an ESP32-S3 over USB-Serial/JTAG, right after a completed `writeFlash`:

- `readFlash` returned zeros for a write that a ROM-level verify proved correct
- `flashMd5sum(0, size)` returned the identical constant for two different images

## Fix

`this.transport.flushInput()` before sending each command - same as esptool.py draining input before issuing commands. Stale bytes have no legitimate consumer: every command in this library is write-then-read with no interleaving.

## Testing

- [ ] `flashMd5sum` after `writeFlash` returns the written image's md5
- [ ] `readFlash` after `writeFlash` returns actual flash contents