### PR TITLE
add s3 h2 support for USB_RAM_BLOCK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies and build 🔧
         run: npm ci && npm run build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install Node modules
         run: |
           npm install

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -6,10 +6,7 @@ import {
   UnsupportedCommandError,
 } from "./types/error.js";
 import { Data, deflate, Inflate } from "pako";
-import {
-  Transport,
-  SerialOptions,
-} from "./webserial.js";
+import { Transport, SerialOptions } from "./webserial.js";
 import { ROM } from "./targets/rom.js";
 import { ClassicReset, CustomReset, HardReset, ResetConstructors, ResetStrategy, UsbJtagSerialReset } from "./reset.js";
 import { getStubJsonByChipName } from "./stubFlasher.js";

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -6,7 +6,10 @@ import {
   UnsupportedCommandError,
 } from "./types/error.js";
 import { Data, deflate, Inflate } from "pako";
-import { Transport, SerialOptions } from "./webserial.js";
+import {
+  Transport,
+  SerialOptions,
+} from "./webserial.js";
 import { ROM } from "./targets/rom.js";
 import { ClassicReset, CustomReset, HardReset, ResetConstructors, ResetStrategy, UsbJtagSerialReset } from "./reset.js";
 import { getStubJsonByChipName } from "./stubFlasher.js";
@@ -28,6 +31,12 @@ import { parseSecurityFlags, SecurityInfo } from "./types/securityInfo.js";
  * @param {number} totalSize - The total size of the data to be read in bytes.
  */
 export type FlashReadCallback = ((packet: Uint8Array, progress: number, totalSize: number) => void) | null;
+
+/** Espressif USB vendor ID used by native USB-Serial/JTAG and USB-OTG. */
+export const ESPRESSIF_VID = 0x303a;
+
+/** Default USB product ID for Espressif USB-Serial/JTAG. */
+export const USB_JTAG_SERIAL_PID = 0x1001;
 
 /**
  * Return the chip ROM based on the given magic number
@@ -169,9 +178,6 @@ export class ESPLoader {
     0x39: "32MB",
     0x3a: "64MB",
   };
-
-  USB_JTAG_SERIAL_PID = 0x1001;
-  ESPRESSIF_VID = 0x303a;
 
   chip!: ROM;
   IS_STUB: boolean;
@@ -600,12 +606,53 @@ export class ESPLoader {
   }
 
   /**
-   * True when the serial device is Espressif USB with the given product ID.
-   * @param {number} pid USB product ID to match
-   * @returns {boolean} Whether VID is Espressif and PID matches
+   * True when Web Serial reports Espressif USB-Serial/JTAG VID/PID.
+   * Safe before chip identify/sync (no register reads).
    */
-  isEspressifUsb(pid: number): boolean {
-    return this.transport.getVid() === this.ESPRESSIF_VID && this.transport.getPid() === pid;
+  private isUsbJtagSerialPort(): boolean {
+    return this.transport.getVid() === ESPRESSIF_VID && this.transport.getPid() === USB_JTAG_SERIAL_PID;
+  }
+
+  /**
+   * True if the host sees this port as Espressif USB-OTG (VID/PID match).
+   * Falls back to the chip UARTDEV_BUF_NO helper when Web Serial omits IDs
+   * or the USB product ID was customized.
+   */
+  async usesUsbOtg(): Promise<boolean> {
+    const vid = this.transport.getVid();
+    const pid = this.transport.getPid();
+    if (vid === ESPRESSIF_VID && this.chip.IMAGE_CHIP_ID != null && pid === this.chip.IMAGE_CHIP_ID) {
+      return true;
+    }
+    if (vid === ESPRESSIF_VID && pid === USB_JTAG_SERIAL_PID) {
+      return false;
+    }
+    if (vid !== undefined && vid !== ESPRESSIF_VID) {
+      return false;
+    }
+    if (typeof this.chip.usesUsbOtg === "function") {
+      return await this.chip.usesUsbOtg(this);
+    }
+    if (typeof this.chip.usingUsbOtg === "function") {
+      return await this.chip.usingUsbOtg(this);
+    }
+    return false;
+  }
+
+  /**
+   * Cap FLASH_WRITE_SIZE to USB_RAM_BLOCK when the stub is talking over
+   * USB-OTG. Matches esptool.py's stub USB buffer limit; USB-Serial/JTAG
+   * and USB-UART bridges keep the 16 KB default.
+   */
+  private async applyUsbFlashWriteSize() {
+    const usbRamBlock = this.chip.USB_RAM_BLOCK;
+    if (!usbRamBlock) {
+      return;
+    }
+    if (await this.usesUsbOtg()) {
+      this.FLASH_WRITE_SIZE = usbRamBlock;
+      this.debug(`Using USB_RAM_BLOCK (0x${usbRamBlock.toString(16)}) for FLASH_WRITE_SIZE (USB-OTG)`);
+    }
   }
 
   /**
@@ -616,24 +663,25 @@ export class ESPLoader {
    * @returns {ResetStrategy[]} - Array of reset strategies
    */
   constructResetSequence(mode: Before): ResetStrategy[] {
-    if (mode !== "no_reset") {
-      if (mode === "usb_reset" || this.isEspressifUsb(this.USB_JTAG_SERIAL_PID)) {
-        // Custom reset sequence, which is required when the device
-        // is connecting via its USB-JTAG-Serial peripheral
-        if (this.resetConstructors.usbJTAGSerialReset) {
-          this.debug("using USB JTAG Serial Reset");
-          return [this.resetConstructors.usbJTAGSerialReset(this.transport)];
-        }
-      } else {
-        const DEFAULT_RESET_DELAY = 50;
-        const EXTRA_DELAY = DEFAULT_RESET_DELAY + 500;
-        if (this.resetConstructors.classicReset) {
-          this.debug("using Classic Serial Reset");
-          return [
-            this.resetConstructors.classicReset(this.transport, DEFAULT_RESET_DELAY),
-            this.resetConstructors.classicReset(this.transport, EXTRA_DELAY),
-          ];
-        }
+    if (mode === "no_reset") {
+      return [];
+    }
+    if (mode === "usb_reset" || this.isUsbJtagSerialPort()) {
+      // Custom reset sequence, which is required when the device
+      // is connecting via its USB-JTAG-Serial peripheral
+      if (this.resetConstructors.usbJTAGSerialReset) {
+        this.debug("using USB JTAG Serial Reset");
+        return [this.resetConstructors.usbJTAGSerialReset(this.transport)];
+      }
+    } else {
+      const DEFAULT_RESET_DELAY = 50;
+      const EXTRA_DELAY = DEFAULT_RESET_DELAY + 500;
+      if (this.resetConstructors.classicReset) {
+        this.debug("using Classic Serial Reset");
+        return [
+          this.resetConstructors.classicReset(this.transport, DEFAULT_RESET_DELAY),
+          this.resetConstructors.classicReset(this.transport, EXTRA_DELAY),
+        ];
       }
     }
 
@@ -1467,6 +1515,8 @@ export class ESPLoader {
   async runStub(): Promise<ROM> {
     if (this.syncStubDetected) {
       this.info("Stub is already running. No upload is necessary.");
+      this.IS_STUB = true;
+      await this.applyUsbFlashWriteSize();
       return this.chip;
     }
 
@@ -1511,6 +1561,7 @@ export class ESPLoader {
 
     this.info("Stub running...");
     this.IS_STUB = true;
+    await this.applyUsbFlashWriteSize();
     return this.chip;
   }
 
@@ -1996,7 +2047,7 @@ export class ESPLoader {
   /**
    * Execute this function to execute after operation reset functions.
    * @param {After} mode After operation mode. Default is 'hard_reset'.
-   * @param { boolean } usingUsbOtg For 'hard_reset' to specify if using USB-OTG
+   * @param { boolean } usingUsbOtg For 'hard_reset'. When omitted, detected via usesUsbOtg()
    * @param {string} sequenceString For 'custom_reset' to specify the custom reset sequence string
    */
   async after(mode: After = "hard_reset", usingUsbOtg?: boolean, sequenceString?: string) {
@@ -2004,7 +2055,8 @@ export class ESPLoader {
       case "hard_reset":
         if (this.resetConstructors.hardReset) {
           this.info("Hard resetting via RTS pin...");
-          const hardReset = this.resetConstructors.hardReset(this.transport, usingUsbOtg);
+          const usbOtg = usingUsbOtg ?? (await this.usesUsbOtg());
+          const hardReset = this.resetConstructors.hardReset(this.transport, usbOtg);
           await hardReset.reset();
         }
         break;

--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -1,6 +1,11 @@
 import { ESPError } from "./types/error.js";
 import { Data, deflate, Inflate } from "pako";
-import { Transport, SerialOptions } from "./webserial.js";
+import {
+  Transport,
+  SerialOptions,
+  ESPRESSIF_VID as ESPRESSIF_USB_VID,
+  USB_JTAG_SERIAL_PID as ESPRESSIF_USB_JTAG_SERIAL_PID,
+} from "./webserial.js";
 import { ROM } from "./targets/rom.js";
 import { ClassicReset, CustomReset, HardReset, ResetConstructors, ResetStrategy, UsbJtagSerialReset } from "./reset.js";
 import { getStubJsonByChipName } from "./stubFlasher.js";
@@ -159,7 +164,8 @@ export class ESPLoader {
     0x3a: "64MB",
   };
 
-  USB_JTAG_SERIAL_PID = 0x1001;
+  ESPRESSIF_VID = ESPRESSIF_USB_VID;
+  USB_JTAG_SERIAL_PID = ESPRESSIF_USB_JTAG_SERIAL_PID;
 
   chip!: ROM;
   IS_STUB: boolean;
@@ -583,6 +589,71 @@ export class ESPLoader {
     }
 
     return lastError;
+  }
+
+  /**
+   * True if the host sees this port as Espressif USB Serial/JTAG (VID/PID match).
+   * Falls back to the chip UARTDEV_BUF_NO helper when Web Serial omits IDs
+   * or the USB product ID was customized.
+   */
+  async usesUsbJtagSerial(): Promise<boolean> {
+    const vid = this.transport.getVid();
+    const pid = this.transport.getPid();
+    if (vid === this.ESPRESSIF_VID && pid === this.USB_JTAG_SERIAL_PID) {
+      return true;
+    }
+    if (vid === this.ESPRESSIF_VID && pid === this.chip.IMAGE_CHIP_ID) {
+      return false;
+    }
+    if (vid !== undefined && vid !== this.ESPRESSIF_VID) {
+      return false;
+    }
+    if (typeof this.chip.usesUsbJtagSerial === "function") {
+      return await this.chip.usesUsbJtagSerial(this);
+    }
+    return false;
+  }
+
+  /**
+   * True if the host sees this port as Espressif USB-OTG (VID/PID match).
+   * Falls back to the chip UARTDEV_BUF_NO helper when Web Serial omits IDs
+   * or the USB product ID was customized.
+   */
+  async usesUsbOtg(): Promise<boolean> {
+    const vid = this.transport.getVid();
+    const pid = this.transport.getPid();
+    if (vid === this.ESPRESSIF_VID && this.chip.IMAGE_CHIP_ID != null && pid === this.chip.IMAGE_CHIP_ID) {
+      return true;
+    }
+    if (vid === this.ESPRESSIF_VID && pid === this.USB_JTAG_SERIAL_PID) {
+      return false;
+    }
+    if (vid !== undefined && vid !== this.ESPRESSIF_VID) {
+      return false;
+    }
+    if (typeof this.chip.usesUsbOtg === "function") {
+      return await this.chip.usesUsbOtg(this);
+    }
+    if (typeof this.chip.usingUsbOtg === "function") {
+      return await this.chip.usingUsbOtg(this);
+    }
+    return false;
+  }
+
+  /**
+   * Cap FLASH_WRITE_SIZE to USB_RAM_BLOCK when the stub is talking over
+   * USB-OTG. Matches esptool.py's stub USB buffer limit; USB-Serial/JTAG
+   * and USB-UART bridges keep the 16 KB default.
+   */
+  private async applyUsbFlashWriteSize() {
+    const usbRamBlock = this.chip.USB_RAM_BLOCK;
+    if (!usbRamBlock) {
+      return;
+    }
+    if (await this.usesUsbOtg()) {
+      this.FLASH_WRITE_SIZE = usbRamBlock;
+      this.debug(`Using USB_RAM_BLOCK (0x${usbRamBlock.toString(16)}) for FLASH_WRITE_SIZE (USB-OTG)`);
+    }
   }
 
   /**
@@ -1272,6 +1343,8 @@ export class ESPLoader {
   async runStub(): Promise<ROM> {
     if (this.syncStubDetected) {
       this.info("Stub is already running. No upload is necessary.");
+      this.IS_STUB = true;
+      await this.applyUsbFlashWriteSize();
       return this.chip;
     }
 
@@ -1311,6 +1384,7 @@ export class ESPLoader {
 
     this.info("Stub running...");
     this.IS_STUB = true;
+    await this.applyUsbFlashWriteSize();
     return this.chip;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export {
   ResetStrategy,
 } from "./reset.js";
 export { ROM } from "./targets/rom.js";
-export { Transport, SerialOptions } from "./webserial.js";
+export { Transport, SerialOptions, ESPRESSIF_VID, USB_JTAG_SERIAL_PID } from "./webserial.js";
 export { decodeBase64Data, getStubJsonByChipName, Stub } from "./stubFlasher.js";
 export { LoaderOptions } from "./types/loaderOptions.js";
 export { FlashOptions } from "./types/flashOptions.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { ESPLoader, FlashReadCallback } from "./esploader.js";
+export { ESPLoader, FlashReadCallback, ESPRESSIF_VID, USB_JTAG_SERIAL_PID } from "./esploader.js";
 export {
   ESPError,
   TimeoutError,

--- a/src/targets/esp32e22.ts
+++ b/src/targets/esp32e22.ts
@@ -173,7 +173,7 @@ export class ESP32E22ROM extends ESP32ROM {
   }
 
   public async postConnect(loader: ESPLoader): Promise<void> {
-    if (loader.isEspressifUsb(this.IMAGE_CHIP_ID)) {
+    if (await loader.usesUsbOtg()) {
       loader.ESP_RAM_BLOCK = this.USB_RAM_BLOCK;
     }
   }

--- a/src/targets/esp32h2.ts
+++ b/src/targets/esp32h2.ts
@@ -94,6 +94,11 @@ export class ESP32H2ROM extends ESP32C6ROM {
     }
   }
 
+  public async usesUsbJtagSerial(loader: ESPLoader): Promise<boolean> {
+    const bufNo = (await loader.readReg(this.UARTDEV_BUF_NO)) & 0xff;
+    return bufNo === this.UARTDEV_BUF_NO_USB;
+  }
+
   public async readMac(loader: ESPLoader) {
     let mac0 = await loader.readReg(this.MAC_EFUSE_REG);
     mac0 = mac0 >>> 0;

--- a/src/targets/esp32p4.ts
+++ b/src/targets/esp32p4.ts
@@ -331,7 +331,7 @@ export class ESP32P4ROM extends ESP32ROM {
    * @param {ESPLoader} loader - Loader class to communicate with chip.
    */
   public async postConnect(loader: ESPLoader) {
-    if (await this.usesUsbOtg(loader)) {
+    if (await loader.usesUsbOtg()) {
       loader.ESP_RAM_BLOCK = this.USB_RAM_BLOCK;
     }
     // Disable watchdogs if not in stub mode (stub manages its own watchdogs)

--- a/src/targets/esp32s2.ts
+++ b/src/targets/esp32s2.ts
@@ -268,9 +268,7 @@ export class ESP32S2ROM extends ESP32ROM {
   }
 
   public async postConnect(loader: ESPLoader) {
-    const usingUsbOtg = await this.usingUsbOtg(loader);
-    loader.debug("In _post_connect using USB OTG ?" + usingUsbOtg);
-    if (usingUsbOtg) {
+    if (await loader.usesUsbOtg()) {
       loader.ESP_RAM_BLOCK = this.USB_RAM_BLOCK;
     }
   }

--- a/src/targets/esp32s3.ts
+++ b/src/targets/esp32s3.ts
@@ -207,6 +207,11 @@ export class ESP32S3ROM extends ESP32ROM {
     }
   }
 
+  public async usesUsbJtagSerial(loader: ESPLoader): Promise<boolean> {
+    const bufNo = (await loader.readReg(this.UARTDEV_BUF_NO)) & 0xff;
+    return bufNo === this.UARTDEV_BUF_NO_USB;
+  }
+
   public async readMac(loader: ESPLoader) {
     let mac0 = await loader.readReg(this.MAC_EFUSE_REG);
     mac0 = mac0 >>> 0;

--- a/src/targets/esp32s3.ts
+++ b/src/targets/esp32s3.ts
@@ -201,11 +201,14 @@ export class ESP32S3ROM extends ESP32ROM {
   }
 
   public async postConnect(loader: ESPLoader) {
-    const bufNo = (await loader.readReg(this.UARTDEV_BUF_NO)) & 0xff;
-    loader.debug("In _post_connect " + bufNo);
-    if (bufNo == this.UARTDEV_BUF_NO_USB) {
+    if (await loader.usesUsbOtg()) {
       loader.ESP_RAM_BLOCK = this.USB_RAM_BLOCK;
     }
+  }
+
+  public async usesUsbJtagSerial(loader: ESPLoader): Promise<boolean> {
+    const bufNo = (await loader.readReg(this.UARTDEV_BUF_NO)) & 0xff;
+    return bufNo === this.UARTDEV_BUF_NO_USB;
   }
 
   public async readMac(loader: ESPLoader) {

--- a/src/targets/esp32s31.ts
+++ b/src/targets/esp32s31.ts
@@ -194,7 +194,7 @@ export class ESP32S31ROM extends ESP32C5ROM {
 
   public async postConnect(loader: ESPLoader): Promise<void> {
     // Python uses_usb_otg(): Espressif VID + IMAGE_CHIP_ID as USB-OTG PID
-    if (loader.isEspressifUsb(this.IMAGE_CHIP_ID)) {
+    if (await loader.usesUsbOtg()) {
       loader.ESP_RAM_BLOCK = this.USB_RAM_BLOCK;
     }
   }

--- a/src/targets/rom.ts
+++ b/src/targets/rom.ts
@@ -68,6 +68,21 @@ export abstract class ROM {
   postConnect?(loader: ESPLoader): Promise<void>;
 
   /**
+   * True if the ROM is talking over USB-OTG (UARTDEV_BUF_NO fallback).
+   */
+  usesUsbOtg?(loader: ESPLoader): Promise<boolean>;
+
+  /**
+   * True if the ROM is talking over USB-OTG (ESP32-S2 naming).
+   */
+  usingUsbOtg?(loader: ESPLoader): Promise<boolean>;
+
+  /**
+   * True if the ROM is talking over USB-Serial/JTAG (UARTDEV_BUF_NO fallback).
+   */
+  usesUsbJtagSerial?(loader: ESPLoader): Promise<boolean>;
+
+  /**
    * Get the chip erase size.
    * @param {number} offset - Offset to start erase.
    * @param {number} size - Size to erase.
@@ -108,6 +123,7 @@ export abstract class ROM {
    */
   USES_MAGIC_VALUE = false;
   SPI_ADDR_REG_MSB?: boolean;
+  USB_RAM_BLOCK?: number; // max SLIP payload over native USB (USB-OTG / USB-Serial/JTAG)
   abstract SPI_MOSI_DLEN_OFFS: number; // not in esp8266
   abstract SPI_MISO_DLEN_OFFS: number; // not in esp8266
   abstract SPI_REG_BASE: number;

--- a/src/targets/rom.ts
+++ b/src/targets/rom.ts
@@ -68,6 +68,21 @@ export abstract class ROM {
   postConnect?(loader: ESPLoader): Promise<void>;
 
   /**
+   * True if the ROM is talking over USB-OTG (UARTDEV_BUF_NO fallback).
+   */
+  usesUsbOtg?(loader: ESPLoader): Promise<boolean>;
+
+  /**
+   * True if the ROM is talking over USB-OTG (ESP32-S2 naming).
+   */
+  usingUsbOtg?(loader: ESPLoader): Promise<boolean>;
+
+  /**
+   * True if the ROM is talking over USB-Serial/JTAG (UARTDEV_BUF_NO fallback).
+   */
+  usesUsbJtagSerial?(loader: ESPLoader): Promise<boolean>;
+
+  /**
    * Get the chip erase size.
    * @param {number} offset - Offset to start erase.
    * @param {number} size - Size to erase.
@@ -101,7 +116,8 @@ export abstract class ROM {
   // abstract EFUSE_RD_REG_BASE: number; //esp32
 
   abstract FLASH_WRITE_SIZE: number;
-  // abstract IMAGE_CHIP_ID: number; // not in esp8266
+  IMAGE_CHIP_ID?: number; // not in esp8266
+  USB_RAM_BLOCK?: number; // max SLIP payload over native USB (USB-OTG / USB-Serial/JTAG)
   abstract SPI_MOSI_DLEN_OFFS: number; // not in esp8266
   abstract SPI_MISO_DLEN_OFFS: number; // not in esp8266
   abstract SPI_REG_BASE: number;

--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -1,6 +1,7 @@
 /* global SerialPort, ParityType, FlowControlType */
 
 import { sleep } from "./util";
+
 /**
  * Options for device serialPort.
  * @interface SerialOptions

--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -1,6 +1,13 @@
 /* global SerialPort, ParityType, FlowControlType */
 
 import { sleep } from "./util";
+
+/** Espressif USB vendor ID used by native USB-Serial/JTAG and USB-OTG. */
+export const ESPRESSIF_VID = 0x303a;
+
+/** Default USB product ID for Espressif USB-Serial/JTAG. */
+export const USB_JTAG_SERIAL_PID = 0x1001;
+
 /**
  * Options for device serialPort.
  * @interface SerialOptions
@@ -96,6 +103,14 @@ class Transport {
     return info.usbVendorId && info.usbProductId
       ? `WebSerial VendorID 0x${info.usbVendorId.toString(16)} ProductID 0x${info.usbProductId.toString(16)}`
       : "";
+  }
+
+  /**
+   * Request the serial device vendor id from SerialPortInfo.
+   * @returns {number | undefined} Return the vendor ID.
+   */
+  getVid(): number | undefined {
+    return this.device.getInfo().usbVendorId;
   }
 
   /**


### PR DESCRIPTION
## Description

Fix #255 

This pull request introduces improved detection and handling of Espressif USB-Serial/JTAG and USB-OTG interfaces, with changes to both the core loader logic and chip-specific ROM classes. The main goal is to better distinguish between connection types (USB-Serial/JTAG vs. USB-OTG), adapt flash write sizes accordingly, and expose relevant USB identifiers for external use.

**USB Interface Detection and Handling:**

* Added `usesUsbJtagSerial()` and `usesUsbOtg()` methods to `ESPLoader` to reliably detect if the connection uses Espressif USB-Serial/JTAG or USB-OTG, using both USB VID/PID and chip-specific helpers for fallback.
* When running the stub (`runStub()`), the loader now applies a USB-specific flash write size limit if USB-OTG is detected, matching esptool.py's buffer limits. [[1]](diffhunk://#diff-9c5587f99fb0aa42042f10b8d0d9e019be9130ded25135b21bddd818c86a3873R1346-R1347) [[2]](diffhunk://#diff-9c5587f99fb0aa42042f10b8d0d9e019be9130ded25135b21bddd818c86a3873R1387)
* The `ROM` base class and specific chip classes (`ESP32S3ROM`, `ESP32H2ROM`) now include helper methods (`usesUsbJtagSerial`, `usesUsbOtg`, `usingUsbOtg`) for fallback detection via hardware registers. [[1]](diffhunk://#diff-68e77dbd80f3a69631df6ace15f1e0ab333b02b6332df0a9855f381c4ec9d72fR70-R84) [[2]](diffhunk://#diff-68e77dbd80f3a69631df6ace15f1e0ab333b02b6332df0a9855f381c4ec9d72fL104-R120) [[3]](diffhunk://#diff-0d523654834eccfa17d7736e1a867f106430bfc4b10dc70e21b77ea3cb3c41e3R97-R101) [[4]](diffhunk://#diff-fa09d5936350b27f3b34f7e6e96aaf8ff8e87d11a8f24e2d1eba1615e673f217R210-R214)

**USB VID/PID Constants and Transport Enhancements:**

* Defined and exported constants for Espressif USB vendor ID (`ESPRESSIF_VID`) and USB-Serial/JTAG product ID (`USB_JTAG_SERIAL_PID`) for use throughout the codebase and by consumers. [[1]](diffhunk://#diff-58b9c49c36b3a1c78e53d874cc4691e01b2d9161d89b9d854269be332d08e484R4-R10) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L12-R12) [[3]](diffhunk://#diff-9c5587f99fb0aa42042f10b8d0d9e019be9130ded25135b21bddd818c86a3873L3-R8) [[4]](diffhunk://#diff-9c5587f99fb0aa42042f10b8d0d9e019be9130ded25135b21bddd818c86a3873L162-R168)
* Added `getVid()` method to the `Transport` class to retrieve the USB vendor ID from the connected device.

These changes make USB connection type detection more robust and allow the loader to optimize behavior based on the actual hardware interface in use.

## Related

Replace #257 with an approach closer to esptool.py

## Testing

- [ ] ESP32-S3 native USB (USB-Serial/JTAG), compressed 1.3 MB write previously failing at seq 42

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
