### PR TITLE
Make the compiled package loadable as native ESM

### DIFF
--- a/src/image/base.ts
+++ b/src/image/base.ts
@@ -1,7 +1,7 @@
-import { ESP8266ROM } from "../targets/esp8266";
-import { ROM } from "../targets/rom";
-import { ESPError } from "../types/error";
-import { checksum, ESP_CHECKSUM_MAGIC, padTo } from "../util";
+import { ESP8266ROM } from "../targets/esp8266.js";
+import { ROM } from "../targets/rom.js";
+import { ESPError } from "../types/error.js";
+import { checksum, ESP_CHECKSUM_MAGIC, padTo } from "../util.js";
 
 export const ESP_IMAGE_MAGIC = 0xe9;
 

--- a/src/image/esp32.ts
+++ b/src/image/esp32.ts
@@ -1,8 +1,8 @@
-import { bstrToUi8, ESP_CHECKSUM_MAGIC } from "../util";
-import { alignFilePosition, BaseFirmwareImage, ELFSection, ESP_IMAGE_MAGIC, ImageSegment } from "./base";
-import { ESPError } from "../types/error";
-import { ROM } from "../targets/rom";
-import { ESP32ROM } from "../targets/esp32";
+import { bstrToUi8, ESP_CHECKSUM_MAGIC } from "../util.js";
+import { alignFilePosition, BaseFirmwareImage, ELFSection, ESP_IMAGE_MAGIC, ImageSegment } from "./base.js";
+import { ESPError } from "../types/error.js";
+import { ROM } from "../targets/rom.js";
+import { ESP32ROM } from "../targets/esp32.js";
 
 export class ESP32FirmwareImage extends BaseFirmwareImage {
   securePad: string | null = null;

--- a/src/image/esp8266.ts
+++ b/src/image/esp8266.ts
@@ -1,6 +1,6 @@
-import { ESP8266ROM } from "../targets/esp8266";
-import { bstrToUi8 } from "../util";
-import { BaseFirmwareImage, ESP_IMAGE_MAGIC } from "./base";
+import { ESP8266ROM } from "../targets/esp8266.js";
+import { bstrToUi8 } from "../util.js";
+import { BaseFirmwareImage, ESP_IMAGE_MAGIC } from "./base.js";
 
 export class ESP8266ROMFirmwareImage extends BaseFirmwareImage {
   version = 1;

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -1,9 +1,9 @@
-import { ROM } from "../targets/rom";
-import { ESPError } from "../types/error";
-import { bstrToUi8 } from "../util";
-import { BaseFirmwareImage, ESP_IMAGE_MAGIC } from "./base";
-import { ESP32FirmwareImage } from "./esp32";
-import { ESP8266ROMFirmwareImage, ESP8266V2FirmwareImage } from "./esp8266";
+import { ROM } from "../targets/rom.js";
+import { ESPError } from "../types/error.js";
+import { bstrToUi8 } from "../util.js";
+import { BaseFirmwareImage, ESP_IMAGE_MAGIC } from "./base.js";
+import { ESP32FirmwareImage } from "./esp32.js";
+import { ESP8266ROMFirmwareImage, ESP8266V2FirmwareImage } from "./esp8266.js";
 import {
   ESP32C2FirmwareImage,
   ESP32C3FirmwareImage,
@@ -14,7 +14,7 @@ import {
   ESP32P4FirmwareImage,
   ESP32S2FirmwareImage,
   ESP32S3FirmwareImage,
-} from "./others";
+} from "./others.js";
 
 /**
  * Function to load a firmware image from a Uint8Array or string

--- a/src/image/others.ts
+++ b/src/image/others.ts
@@ -1,13 +1,13 @@
-import { ESP32C2ROM } from "../targets/esp32c2";
-import { ESP32C3ROM } from "../targets/esp32c3";
-import { ESP32C5ROM } from "../targets/esp32c5";
-import { ESP32C6ROM } from "../targets/esp32c6";
-import { ESP32C61ROM } from "../targets/esp32c61";
-import { ESP32H2ROM } from "../targets/esp32h2";
-import { ESP32P4ROM } from "../targets/esp32p4";
-import { ESP32S2ROM } from "../targets/esp32s2";
-import { ESP32S3ROM } from "../targets/esp32s3";
-import { ESP32FirmwareImage } from "./esp32";
+import { ESP32C2ROM } from "../targets/esp32c2.js";
+import { ESP32C3ROM } from "../targets/esp32c3.js";
+import { ESP32C5ROM } from "../targets/esp32c5.js";
+import { ESP32C6ROM } from "../targets/esp32c6.js";
+import { ESP32C61ROM } from "../targets/esp32c61.js";
+import { ESP32H2ROM } from "../targets/esp32h2.js";
+import { ESP32P4ROM } from "../targets/esp32p4.js";
+import { ESP32S2ROM } from "../targets/esp32s2.js";
+import { ESP32S3ROM } from "../targets/esp32s3.js";
+import { ESP32FirmwareImage } from "./esp32.js";
 
 export class ESP32S2FirmwareImage extends ESP32FirmwareImage {
   ROM_LOADER: ESP32S2ROM;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,20 @@
-export { ESPLoader, FlashReadCallback } from "./esploader.js";
+export { ESPLoader } from "./esploader.js";
+export type { FlashReadCallback } from "./esploader.js";
 export {
   ClassicReset,
   CustomReset,
   HardReset,
   UsbJtagSerialReset,
   validateCustomResetStringSequence,
-  ResetConstructors,
-  ResetStrategy,
 } from "./reset.js";
+export type { ResetConstructors, ResetStrategy } from "./reset.js";
 export { ROM } from "./targets/rom.js";
-export { Transport, SerialOptions } from "./webserial.js";
-export { decodeBase64Data, getStubJsonByChipName, Stub } from "./stubFlasher.js";
-export { LoaderOptions } from "./types/loaderOptions.js";
-export { FlashOptions } from "./types/flashOptions.js";
-export { IEspLoaderTerminal } from "./types/loaderTerminal.js";
-export { Before, After } from "./types/resetModes.js";
-export { FlashModeValues, FlashSizeValues, FlashFreqValues } from "./types/arguments.js";
+export { Transport } from "./webserial.js";
+export type { SerialOptions } from "./webserial.js";
+export { decodeBase64Data, getStubJsonByChipName } from "./stubFlasher.js";
+export type { Stub } from "./stubFlasher.js";
+export type { LoaderOptions } from "./types/loaderOptions.js";
+export type { FlashOptions } from "./types/flashOptions.js";
+export type { IEspLoaderTerminal } from "./types/loaderTerminal.js";
+export type { Before, After } from "./types/resetModes.js";
+export type { FlashModeValues, FlashSizeValues, FlashFreqValues } from "./types/arguments.js";

--- a/src/targets/esp32c5.ts
+++ b/src/targets/esp32c5.ts
@@ -1,6 +1,6 @@
-import { ESPLoader } from "../esploader";
-import { ESP32C6ROM } from "./esp32c6";
-import { MemoryMapEntry } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ESP32C6ROM } from "./esp32c6.js";
+import { MemoryMapEntry } from "./rom.js";
 
 export class ESP32C5ROM extends ESP32C6ROM {
   public CHIP_NAME = "ESP32-C5";

--- a/src/targets/esp32c61.ts
+++ b/src/targets/esp32c61.ts
@@ -1,6 +1,6 @@
-import { ESPLoader } from "../esploader";
-import { ESP32C6ROM } from "./esp32c6";
-import { MemoryMapEntry } from "./rom";
+import { ESPLoader } from "../esploader.js";
+import { ESP32C6ROM } from "./esp32c6.js";
+import { MemoryMapEntry } from "./rom.js";
 
 export class ESP32C61ROM extends ESP32C6ROM {
   public CHIP_NAME = "ESP32-C61";

--- a/src/types/flashOptions.ts
+++ b/src/types/flashOptions.ts
@@ -1,4 +1,4 @@
-import { FlashFreqValues, FlashModeValues, FlashSizeValues } from "./arguments";
+import { FlashFreqValues, FlashModeValues, FlashSizeValues } from "./arguments.js";
 
 /**
  * Options for flashing a device with firmware.

--- a/src/types/loaderOptions.ts
+++ b/src/types/loaderOptions.ts
@@ -1,6 +1,6 @@
-import { ResetConstructors } from "../reset";
-import { Transport, SerialOptions } from "../webserial";
-import { IEspLoaderTerminal } from "./loaderTerminal";
+import { ResetConstructors } from "../reset.js";
+import { Transport, SerialOptions } from "../webserial.js";
+import { IEspLoaderTerminal } from "./loaderTerminal.js";
 
 /* global SerialPort */
 

--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -1,6 +1,6 @@
 /* global SerialPort, ParityType, FlowControlType */
 
-import { sleep } from "./util";
+import { sleep } from "./util.js";
 /**
  * Options for device serialPort.
  * @interface SerialOptions


### PR DESCRIPTION
Serving `lib/` to a browser without a bundler fails on the first module. Two independent causes, both in the sources, since TypeScript rewrites no specifiers.

**Relative specifiers carry no extension.** A browser resolves `./webserial` as a URL and requests a file that does not exist, so the module graph never finishes loading. Every relative specifier now ends in `.js`, which the compiler emits verbatim and every bundler already understands.

**Interfaces are re-exported as values.** `export { SerialOptions } from "./webserial.js"` emits a runtime re-export of a binding the compiled module does not have, and the browser throws on load. Each type-only re-export is now `export type`, which emits nothing. `ESPLoader`, `Transport`, `ROM` and the reset classes stay value exports.

The stub JSON, the other half, needs import attributes and so a newer TypeScript, which is a separate change.