### PR TITLE
Add ESP32-C5 revision 1.2 magic value

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -65,7 +65,8 @@ async function magic2Chip(magic: number): Promise<ROM | null> {
     }
     case 0x1101406f:
     case 0x63e1406f:
-    case 0x5fd1406f: {
+    case 0x5fd1406f:
+    case 0x30e1706f: {
       const { ESP32C5ROM } = await import("./targets/esp32c5.js");
       return new ESP32C5ROM();
     }

--- a/src/targets/esp32c5.ts
+++ b/src/targets/esp32c5.ts
@@ -54,7 +54,7 @@ export class ESP32C5ROM extends ESP32C6ROM {
   public UARTDEV_BUF_NO = 0x4085f514; // Variable in ROM .bss which indicates the port in use
 
   // Magic value for ESP32C5
-  public CHIP_DETECT_MAGIC_VALUE = [0x1101406f, 0x63e1406f, 0x5fd1406f];
+  public CHIP_DETECT_MAGIC_VALUE = [0x1101406f, 0x63e1406f, 0x5fd1406f, 0x30e1706f];
 
   public FLASH_FREQUENCY = {
     "80m": 0xf,


### PR DESCRIPTION
## Description

Add the ESP32-C5 revision v1.2 ROM magic value (`0x30e1706f`) to the chip detection switch and the C5 magic-value list.

This keeps fallback detection working when `GET_SECURITY_INFO` is unavailable.

## Testing

- Formatting, lint, and build passed
- Confirmed `0x30e1706f` maps to ESP32-C5 in the browser bundle
- Connected an ESP32-C5 v1.2 successfully
- Tested with an **MDNR8N8** chip
- Stub upload, baud change, and flash ID read passed
