### PR TITLE
fix devkitc security info

### DIFF
--- a/src/esploader.ts
+++ b/src/esploader.ts
@@ -406,7 +406,9 @@ export class ESPLoader {
         if (op == null || opRet == op) {
           return [val, data];
         } else if (data[0] != 0 && data[1] == this.ROM_INVALID_RECV_MSG) {
-          this.transport.flushInput();
+          // The ROM repeats an unsupported command response 8 times; flushing
+          // alone leaves the rest in flight, desyncing the next command.
+          await this.transport.drainInput();
           throw new UnsupportedCommandError();
         }
       }
@@ -810,7 +812,11 @@ export class ESPLoader {
         0,
         20,
       )) as Uint8Array;
-    } catch {
+    } catch (error) {
+      if (error instanceof UnsupportedCommandError) {
+        // ESP8266 and ESP32 have no such command, let the caller fall back
+        throw error;
+      }
       res = (await this.checkCommand(
         "get security info",
         this.ESP_GET_SECURITY_INFO,

--- a/src/webserial.ts
+++ b/src/webserial.ts
@@ -1,5 +1,6 @@
 /* global SerialPort, ParityType, FlowControlType */
 
+import { ESPError } from "./types/error";
 import { sleep } from "./util";
 /**
  * Options for device serialPort.
@@ -268,6 +269,26 @@ class Transport {
     this.buffer = new Uint8Array(0);
   }
 
+  /**
+   * Actively drain the input buffer: wait for in-flight bytes to arrive
+   * (the ROM repeats an unsupported command response 8 times) and discard them.
+   * Flushing alone only drops the bytes already buffered.
+   * @param {number} quietMs Time without new bytes before considering the stream drained
+   * @param {number} maxMs Upper bound on the total wait
+   */
+  async drainInput(quietMs = 100, maxMs = 400) {
+    const deadline = Date.now() + maxMs;
+    let lastLength = -1;
+    while (Date.now() < deadline && this.buffer.length !== lastLength) {
+      lastLength = this.buffer.length;
+      await sleep(quietMs);
+    }
+    if (this.tracing) {
+      this.trace(`Drained ${this.buffer.length} bytes from serial buffer`);
+    }
+    this.flushInput();
+  }
+
   async flushOutput() {
     try {
       if (this.device.writable) {
@@ -346,7 +367,7 @@ class Transport {
         if (this.tracing) {
           this.trace(msg);
         }
-        throw new Error(msg);
+        throw new ESPError(msg);
       }
 
       if (this.tracing) {
@@ -367,7 +388,7 @@ class Transport {
               this.trace(`Remaining data in serial buffer: ${this.hexConvert(remainingData)}`);
             }
             this.detectPanicHandler(new Uint8Array([...readBytes, ...(remainingData || [])]));
-            throw new Error(`Invalid head of packet (0x${byte.toString(16)}): Possible serial noise or corruption.`);
+            throw new ESPError(`Invalid head of packet (0x${byte.toString(16)}): Possible serial noise or corruption.`);
           }
         } else if (isEscaping) {
           isEscaping = false;
@@ -384,7 +405,7 @@ class Transport {
               this.trace(`Remaining data in serial buffer: ${this.hexConvert(remainingData)}`);
             }
             this.detectPanicHandler(new Uint8Array([...readBytes, ...(remainingData || [])]));
-            throw new Error(`Invalid SLIP escape (0xdb, 0x${byte.toString(16)})`);
+            throw new ESPError(`Invalid SLIP escape (0xdb, 0x${byte.toString(16)})`);
           }
         } else if (byte === this.SLIP_ESC) {
           isEscaping = true;


### PR DESCRIPTION

## Description

Fix #263 

This pull request improves how unsupported command responses and serial buffer errors are handled in the ESP loader and transport logic. The main focus is on reliably draining repeated unsupported command responses from the serial input to prevent desynchronization, and on providing clearer error handling with custom error types.

**Serial buffer management improvements:**

* Added a new `drainInput` method to the `Transport` class in `src/webserial.ts` to actively wait for and discard all in-flight bytes, addressing the issue where the ROM repeats unsupported command responses multiple times and flushing alone is insufficient. (`[src/webserial.tsR272-R291](diffhunk://#diff-58b9c49c36b3a1c78e53d874cc4691e01b2d9161d89b9d854269be332d08e484R272-R291)`)
* Updated the ESP loader (`src/esploader.ts`) to use `await this.transport.drainInput()` instead of just flushing when encountering repeated unsupported command responses, preventing command desynchronization. (`[src/esploader.tsL409-R411](diffhunk://#diff-9c5587f99fb0aa42042f10b8d0d9e019be9130ded25135b21bddd818c86a3873L409-R411)`)

**Error handling enhancements:**

* Replaced generic `Error` throws with a custom `ESPError` for serial buffer and SLIP protocol errors in `src/webserial.ts`, providing more meaningful error messages and easier error handling. (`[[1]](diffhunk://#diff-58b9c49c36b3a1c78e53d874cc4691e01b2d9161d89b9d854269be332d08e484L349-R370)`, `[[2]](diffhunk://#diff-58b9c49c36b3a1c78e53d874cc4691e01b2d9161d89b9d854269be332d08e484L370-R391)`, `[[3]](diffhunk://#diff-58b9c49c36b3a1c78e53d874cc4691e01b2d9161d89b9d854269be332d08e484L387-R408)`)
* Improved error handling in the ESP loader by catching `UnsupportedCommandError` specifically, allowing proper fallback for unsupported commands. (`[src/esploader.tsL813-R819](diffhunk://#diff-9c5587f99fb0aa42042f10b8d0d9e019be9130ded25135b21bddd818c86a3873L813-R819)`)
* Imported `ESPError` in `src/webserial.ts` for use in the new error handling logic. (`[src/webserial.tsR3](diffhunk://#diff-58b9c49c36b3a1c78e53d874cc4691e01b2d9161d89b9d854269be332d08e484R3)`)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
